### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "@angular-eslint/schematics": "^14.1.2",
         "@angular-eslint/template-parser": "^14.1.2",
         "@angular/cli": "^14.2.6",
-        "@angular/common": "^14.2.6",
-        "@angular/compiler": "^14.2.6",
-        "@angular/compiler-cli": "^14.2.6",
-        "@angular/platform-browser": "^14.2.6",
-        "@angular/platform-browser-dynamic": "^14.2.6",
+        "@angular/common": "^14.2.7",
+        "@angular/compiler": "^14.2.7",
+        "@angular/compiler-cli": "^14.2.7",
+        "@angular/platform-browser": "^14.2.7",
+        "@angular/platform-browser-dynamic": "^14.2.7",
         "@types/jasmine": "^4.3.0",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^18.11.3",
@@ -48,7 +48,7 @@
         "zone.js": "^0.11.8"
       },
       "peerDependencies": {
-        "@angular/core": "^14.2.6"
+        "@angular/core": "^14.2.7"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.6.tgz",
-      "integrity": "sha512-WNX7xe8LKP5DHPlae+c77PDwj0iIAAPIe1lWbhQysyi8uttbtL9VVP2XTFuQ3E6oVHJr+0IR0LMVGJ+a8i6zsw==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.7.tgz",
+      "integrity": "sha512-vfydeB8urLzhRnZev/1Zm87k9jWlNfhSTk09yUnqvzcORfd3xOkcei0qc1xdIHCTEMyTREC+umsYHDmlEpZsVw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -533,14 +533,14 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "14.2.6",
+        "@angular/core": "14.2.7",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.6.tgz",
-      "integrity": "sha512-XtmJRNQQ/bUcRjB6jG67km3EPug8frnHH50sLqxye+cljCzWQpzFN/Qr1z0abuzEX8OC4alqxCDCFgTFyyVkaQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.7.tgz",
+      "integrity": "sha512-2I8hZVM/tfUi06B6VuWgf5hWu0tgNlMCEZ1Ed4NEDkqJj+gs2l6kNVUf+FxI6hHMZTFkJPXOPx3pI5Hea5CxEQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -549,7 +549,7 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "14.2.6"
+        "@angular/core": "14.2.7"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -558,9 +558,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.6.tgz",
-      "integrity": "sha512-zKnpZ5WDbM31dwr5GDAbCblMIEUzWSglUyqCxJfbCg21dE0EuLfd/WzsROgM2TucOtCT5xNipqz4bc+wdEOIgQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.7.tgz",
+      "integrity": "sha512-q6AQo91jc+Pd1PnWWxJq07IXr1yipq0MW3Uok5akEctbTsw4AT5y9wfPj6g/o/CkAz0kbL55QrmtyIWN5LMGdg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.17.2",
@@ -583,14 +583,14 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "14.2.6",
+        "@angular/compiler": "14.2.7",
         "typescript": ">=4.6.2 <4.9"
       }
     },
     "node_modules/@angular/core": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.6.tgz",
-      "integrity": "sha512-fEIz7E488X03tLIqmWQRpahxRRU2SMjb9i/rMUjMQJkbppJC3cykl31bCYzeixNO+zpE55GPGuQX2qI/yDenZA==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.7.tgz",
+      "integrity": "sha512-9u2eeKS90YPh2b0pK5LKFSxKfLIzHnzkIKQFh6bEPGj43Fl2v8CwiVJu1CAKo1Or4qBY8zspSowM6S1kgGwfeg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -604,9 +604,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.6.tgz",
-      "integrity": "sha512-KQUN4YVYEK5NOL7QFnDulQta6tm9rPh/mruX/XCLkSmoRMlFBmsHyjx+VJBnBNUbUxNsBj7kknifOu9PqDgAWg==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.7.tgz",
+      "integrity": "sha512-Hcn64kppozH5WlX/rkZoCGZyFFkLs0a4+rWen6uaZVxDWbas/PqR/a2LQerdS0Rn65/x+0l0w23u8TN0PnQPVA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -615,9 +615,9 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "14.2.6",
-        "@angular/common": "14.2.6",
-        "@angular/core": "14.2.6"
+        "@angular/animations": "14.2.7",
+        "@angular/common": "14.2.7",
+        "@angular/core": "14.2.7"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.6.tgz",
-      "integrity": "sha512-SlWEYLED4ST1AFfgeB8SyKLVJYp36XT+3Vw3yDrObsthzXCiFAuYHQZfSWgT1Sfx3uFqEdN7nskJqD05wN3mQg==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.7.tgz",
+      "integrity": "sha512-P3c4fXH0+RDlL9uzuU5Xea5OQ3ozmoWawFtf4faH7fD3deHlNmrwROBXAlHkYRjbGcAiuxpEx6NjBGdmYWPaKg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -637,10 +637,10 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "14.2.6",
-        "@angular/compiler": "14.2.6",
-        "@angular/core": "14.2.6",
-        "@angular/platform-browser": "14.2.6"
+        "@angular/common": "14.2.7",
+        "@angular/compiler": "14.2.7",
+        "@angular/core": "14.2.7",
+        "@angular/platform-browser": "14.2.7"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -16519,27 +16519,27 @@
       }
     },
     "@angular/common": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.6.tgz",
-      "integrity": "sha512-WNX7xe8LKP5DHPlae+c77PDwj0iIAAPIe1lWbhQysyi8uttbtL9VVP2XTFuQ3E6oVHJr+0IR0LMVGJ+a8i6zsw==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.7.tgz",
+      "integrity": "sha512-vfydeB8urLzhRnZev/1Zm87k9jWlNfhSTk09yUnqvzcORfd3xOkcei0qc1xdIHCTEMyTREC+umsYHDmlEpZsVw==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.6.tgz",
-      "integrity": "sha512-XtmJRNQQ/bUcRjB6jG67km3EPug8frnHH50sLqxye+cljCzWQpzFN/Qr1z0abuzEX8OC4alqxCDCFgTFyyVkaQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.7.tgz",
+      "integrity": "sha512-2I8hZVM/tfUi06B6VuWgf5hWu0tgNlMCEZ1Ed4NEDkqJj+gs2l6kNVUf+FxI6hHMZTFkJPXOPx3pI5Hea5CxEQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.6.tgz",
-      "integrity": "sha512-zKnpZ5WDbM31dwr5GDAbCblMIEUzWSglUyqCxJfbCg21dE0EuLfd/WzsROgM2TucOtCT5xNipqz4bc+wdEOIgQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.7.tgz",
+      "integrity": "sha512-q6AQo91jc+Pd1PnWWxJq07IXr1yipq0MW3Uok5akEctbTsw4AT5y9wfPj6g/o/CkAz0kbL55QrmtyIWN5LMGdg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.17.2",
@@ -16555,27 +16555,27 @@
       }
     },
     "@angular/core": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.6.tgz",
-      "integrity": "sha512-fEIz7E488X03tLIqmWQRpahxRRU2SMjb9i/rMUjMQJkbppJC3cykl31bCYzeixNO+zpE55GPGuQX2qI/yDenZA==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.7.tgz",
+      "integrity": "sha512-9u2eeKS90YPh2b0pK5LKFSxKfLIzHnzkIKQFh6bEPGj43Fl2v8CwiVJu1CAKo1Or4qBY8zspSowM6S1kgGwfeg==",
       "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.6.tgz",
-      "integrity": "sha512-KQUN4YVYEK5NOL7QFnDulQta6tm9rPh/mruX/XCLkSmoRMlFBmsHyjx+VJBnBNUbUxNsBj7kknifOu9PqDgAWg==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.7.tgz",
+      "integrity": "sha512-Hcn64kppozH5WlX/rkZoCGZyFFkLs0a4+rWen6uaZVxDWbas/PqR/a2LQerdS0Rn65/x+0l0w23u8TN0PnQPVA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.6.tgz",
-      "integrity": "sha512-SlWEYLED4ST1AFfgeB8SyKLVJYp36XT+3Vw3yDrObsthzXCiFAuYHQZfSWgT1Sfx3uFqEdN7nskJqD05wN3mQg==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.7.tgz",
+      "integrity": "sha512-P3c4fXH0+RDlL9uzuU5Xea5OQ3ozmoWawFtf4faH7fD3deHlNmrwROBXAlHkYRjbGcAiuxpEx6NjBGdmYWPaKg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^14.2.6"
+    "@angular/core": "^14.2.7"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.2.6",
@@ -37,11 +37,11 @@
     "@angular-eslint/schematics": "^14.1.2",
     "@angular-eslint/template-parser": "^14.1.2",
     "@angular/cli": "^14.2.6",
-    "@angular/common": "^14.2.6",
-    "@angular/compiler": "^14.2.6",
-    "@angular/compiler-cli": "^14.2.6",
-    "@angular/platform-browser": "^14.2.6",
-    "@angular/platform-browser-dynamic": "^14.2.6",
+    "@angular/common": "^14.2.7",
+    "@angular/compiler": "^14.2.7",
+    "@angular/compiler-cli": "^14.2.7",
+    "@angular/platform-browser": "^14.2.7",
+    "@angular/platform-browser-dynamic": "^14.2.7",
     "@types/jasmine": "^4.3.0",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^18.11.3",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/core                           14.2.6 -> 14.2.7         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>