### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^14.2.6",
+        "@angular-devkit/build-angular": "^14.2.7",
         "@angular-eslint/builder": "^14.1.2",
         "@angular-eslint/eslint-plugin": "^14.1.2",
         "@angular-eslint/eslint-plugin-template": "^14.1.2",
         "@angular-eslint/schematics": "^14.1.2",
         "@angular-eslint/template-parser": "^14.1.2",
-        "@angular/cli": "^14.2.6",
-        "@angular/common": "^14.2.7",
-        "@angular/compiler": "^14.2.7",
-        "@angular/compiler-cli": "^14.2.7",
-        "@angular/platform-browser": "^14.2.7",
-        "@angular/platform-browser-dynamic": "^14.2.7",
+        "@angular/cli": "^14.2.7",
+        "@angular/common": "^14.2.8",
+        "@angular/compiler": "^14.2.8",
+        "@angular/compiler-cli": "^14.2.8",
+        "@angular/platform-browser": "^14.2.8",
+        "@angular/platform-browser-dynamic": "^14.2.8",
         "@types/jasmine": "^4.3.0",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^18.11.7",
@@ -48,7 +48,7 @@
         "zone.js": "^0.11.8"
       },
       "peerDependencies": {
-        "@angular/core": "^14.2.7"
+        "@angular/core": "^14.2.8"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -70,12 +70,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1402.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.6.tgz",
-      "integrity": "sha512-qTmPBD7fBXBtlSapGLUEcJvRuL/O556zCFFpH3kSlzPNTYxi2falBjGY+4aG+078RXT1vVZtFsvRTart6VbhAg==",
+      "version": "0.1402.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.7.tgz",
+      "integrity": "sha512-YZchteri2iUq5JICSH0BQjOU3ehE57+CMU8PBigcJZiaLa/GPiCuwD9QOsnwSzHJNYYx5C94uhtZUjPwUtIAIw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.6",
+        "@angular-devkit/core": "14.2.7",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -103,15 +103,15 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.6.tgz",
-      "integrity": "sha512-XtaUwb3aZ8S0vl0y9bmbdFOH0KQCQ778twFH+ZfHW2BcPYtQz2Cy2rcVKXBQ850RyC0GxgMPfco6OGQndPpizg==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.7.tgz",
+      "integrity": "sha512-Y58kcEmy8bSFyODtUFQzkuoZHNCji3fzRwGCiQYdAh/mkBf53CuVWoT9q7MrvGOc7Nmo2JiuwR/b7c543eVgfw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1402.6",
-        "@angular-devkit/build-webpack": "0.1402.6",
-        "@angular-devkit/core": "14.2.6",
+        "@angular-devkit/architect": "0.1402.7",
+        "@angular-devkit/build-webpack": "0.1402.7",
+        "@angular-devkit/core": "14.2.7",
         "@babel/core": "7.18.10",
         "@babel/generator": "7.18.12",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -122,7 +122,7 @@
         "@babel/runtime": "7.18.9",
         "@babel/template": "7.18.10",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "14.2.6",
+        "@ngtools/webpack": "14.2.7",
         "ansi-colors": "4.1.3",
         "babel-loader": "8.2.5",
         "babel-plugin-istanbul": "6.1.1",
@@ -267,12 +267,12 @@
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1402.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.6.tgz",
-      "integrity": "sha512-gKsDxQ9pze0N1qDM0kdM4FfwpkjSOb0bQzqjZi7wTfrh/WGIQMCjG9CRwWT+Z289ZKaTpcQDPsDtOSo5QpKNDg==",
+      "version": "0.1402.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.7.tgz",
+      "integrity": "sha512-aDhS/ODt8BwgtnNN73R7SuMC1GgoT5Pajn1nnIWvvpGj8XchLUbguptyl2v7D2QeYXXsd34Gtx8cDOr9PxYFTA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1402.6",
+        "@angular-devkit/architect": "0.1402.7",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -304,9 +304,9 @@
       "dev": true
     },
     "node_modules/@angular-devkit/core": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.6.tgz",
-      "integrity": "sha512-qtRSdRm/h7C3ya04PJTDgQXV6mM8Y4RakANX1GTSXetCf9AVSxg74NJX76DWUgiHT4JiPYnJgJU6Hr/L0H6JOQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.7.tgz",
+      "integrity": "sha512-83SCYP3h6fglWMgAXFDc8HfOxk9t3ugK0onATXchctvA7blW4Vx8BSg3/DgbqCv+fF380SN8bYqqLJl8fQFdzg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.11.0",
@@ -348,12 +348,12 @@
       "dev": true
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.6.tgz",
-      "integrity": "sha512-mSFtc4M49mWrYsgJx/P6bA6SzXb8SeZqmppKRMoEQxiXI1bwFdGLNWzAmzEsGvS96h/nPIaOfcX5cKJSp++4FA==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.7.tgz",
+      "integrity": "sha512-3e2dpFXWl2Z4Gfm+KgY3gAeqsyu8utJMcDIg5sWRAXDeJJdAPc5LweCa8YZEn33Zr9cl8oK+FxlOr15RCyWLcA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.6",
+        "@angular-devkit/core": "14.2.7",
         "jsonc-parser": "3.1.0",
         "magic-string": "0.26.2",
         "ora": "5.4.1",
@@ -486,15 +486,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.6.tgz",
-      "integrity": "sha512-8tXpe3htfZY8a+Am4nluVcztMFD5wnx4edGEDkkOiqkrUzbCtX4AyEBjUFldsYKZXbRFU46xEfM6jBnLOjxDZQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.7.tgz",
+      "integrity": "sha512-RM4CJwtqD7cKFQ7hNGJ56s9YMeJxYqCN5Ss0SzsKN1nXYqz8HykMW8fhUbZQ9HFVy/Ml3LGoh1yGo/tXywAWcA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1402.6",
-        "@angular-devkit/core": "14.2.6",
-        "@angular-devkit/schematics": "14.2.6",
-        "@schematics/angular": "14.2.6",
+        "@angular-devkit/architect": "0.1402.7",
+        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/schematics": "14.2.7",
+        "@schematics/angular": "14.2.7",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "debug": "4.3.4",
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.7.tgz",
-      "integrity": "sha512-vfydeB8urLzhRnZev/1Zm87k9jWlNfhSTk09yUnqvzcORfd3xOkcei0qc1xdIHCTEMyTREC+umsYHDmlEpZsVw==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.8.tgz",
+      "integrity": "sha512-JSPN2h1EcyWjHWtOzRQmoX48ZacTjLAYwW9ZRmBpYs6Ptw5xZ39ARTJfQNcNnJleqYju2E6BNkGnLpbtWQjNDA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -533,14 +533,14 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "14.2.7",
+        "@angular/core": "14.2.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.7.tgz",
-      "integrity": "sha512-2I8hZVM/tfUi06B6VuWgf5hWu0tgNlMCEZ1Ed4NEDkqJj+gs2l6kNVUf+FxI6hHMZTFkJPXOPx3pI5Hea5CxEQ==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.8.tgz",
+      "integrity": "sha512-lKwp3B4ZKNLgk/25Iyur8bjAwRL20auRoB4EuHrBf+928ftsjYUXTgi+0++DUjPENbpi59k6GcvMCNa6qccvIw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -549,7 +549,7 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "14.2.7"
+        "@angular/core": "14.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -558,9 +558,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.7.tgz",
-      "integrity": "sha512-q6AQo91jc+Pd1PnWWxJq07IXr1yipq0MW3Uok5akEctbTsw4AT5y9wfPj6g/o/CkAz0kbL55QrmtyIWN5LMGdg==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.8.tgz",
+      "integrity": "sha512-QTftNrAyXOWzKFGY6/i9jh0LB2cOxmykepG4c53wH9LblGvWFztlVOhcoU8tpQSSH8t3EYvGs2r8oUuxcYm5Cw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.17.2",
@@ -583,14 +583,14 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "14.2.7",
+        "@angular/compiler": "14.2.8",
         "typescript": ">=4.6.2 <4.9"
       }
     },
     "node_modules/@angular/core": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.7.tgz",
-      "integrity": "sha512-9u2eeKS90YPh2b0pK5LKFSxKfLIzHnzkIKQFh6bEPGj43Fl2v8CwiVJu1CAKo1Or4qBY8zspSowM6S1kgGwfeg==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.8.tgz",
+      "integrity": "sha512-cgnII9vJGJDLsfr7KsBfU2l+QQUmQIRIP3ImKhBxicw2IHKCSb2mYwoeLV46jaLyHyUMTLRHKUYUR4XtSPnb8A==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -604,9 +604,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.7.tgz",
-      "integrity": "sha512-Hcn64kppozH5WlX/rkZoCGZyFFkLs0a4+rWen6uaZVxDWbas/PqR/a2LQerdS0Rn65/x+0l0w23u8TN0PnQPVA==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.8.tgz",
+      "integrity": "sha512-tSASBLXoBE0/Gt6d2nC6BJ1DvbGY5wo2Lb+8WCLSvkfsgVqOh4uRuJ2a0wwjeLFd0ZNmpjG42Ijba4btmCpIjg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -615,9 +615,9 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "14.2.7",
-        "@angular/common": "14.2.7",
-        "@angular/core": "14.2.7"
+        "@angular/animations": "14.2.8",
+        "@angular/common": "14.2.8",
+        "@angular/core": "14.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.7.tgz",
-      "integrity": "sha512-P3c4fXH0+RDlL9uzuU5Xea5OQ3ozmoWawFtf4faH7fD3deHlNmrwROBXAlHkYRjbGcAiuxpEx6NjBGdmYWPaKg==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.8.tgz",
+      "integrity": "sha512-CPK8wHnKke8AUKR92XrFuanaKNXDzDm3uVI3DD0NxBo+fLAkiuVaDVIGgO6n6SxQVtwjXJtMXqQuNdzUg4Q9uQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -637,10 +637,10 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "14.2.7",
-        "@angular/compiler": "14.2.7",
-        "@angular/core": "14.2.7",
-        "@angular/platform-browser": "14.2.7"
+        "@angular/common": "14.2.8",
+        "@angular/compiler": "14.2.8",
+        "@angular/core": "14.2.8",
+        "@angular/platform-browser": "14.2.8"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -2882,9 +2882,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.6.tgz",
-      "integrity": "sha512-HdfoHLGPzyP135BOlvTQcpeWisVfiH0u40YNTBVK3QAsrLnY17e2QG5BWBOrVYipRu1975cZtTC9rPjcCY8aLQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.7.tgz",
+      "integrity": "sha512-I47BdEybpzjfFFMFB691o9C+69RexLTgSm/VCyDn4M8DrGrZpgYNhxN+AEr1uA6Bi6MaPG6w+TMac5tNIaO4Yw==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || >=16.10.0",
@@ -3112,13 +3112,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.6.tgz",
-      "integrity": "sha512-oeyMAQr3Q9nvAX+5FRgXcTMX9lqqenElBmAuwfqqdB0qD1jmkJ8TpWRuvYVA/931njpIwhfyLrzmzeNnJb23Sg==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.7.tgz",
+      "integrity": "sha512-ujtLu0gWARtJsRbN+P+McDO0Y0ygJjUN5016SdbmYDMcDJkwi+GYHU8Yvh/UONtmNor3JdV8AnZ8OmWTlswTDA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.6",
-        "@angular-devkit/schematics": "14.2.6",
+        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/schematics": "14.2.7",
         "jsonc-parser": "3.1.0"
       },
       "engines": {
@@ -10454,9 +10454,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.7.tgz",
-      "integrity": "sha512-ygaiUSNalBX85388uskeCyhSAoOSgzBbtVCr9jA2RROssFL9Q19/ZXFqS+2Th2sr1ewNIWgFdLzLC3Yl1Zv+lw==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.9.tgz",
+      "integrity": "sha512-3rm8kbrzpUGRyPKSGuk387NZOwQ90O4rI9tsWQkzNW7BLSnKGp23RsEsKK8N8QVCrtJoAMqy3spxHC4os4G6PQ==",
       "dev": true,
       "dependencies": {
         "fs-monkey": "^1.0.3"
@@ -16165,12 +16165,12 @@
       }
     },
     "@angular-devkit/architect": {
-      "version": "0.1402.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.6.tgz",
-      "integrity": "sha512-qTmPBD7fBXBtlSapGLUEcJvRuL/O556zCFFpH3kSlzPNTYxi2falBjGY+4aG+078RXT1vVZtFsvRTart6VbhAg==",
+      "version": "0.1402.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.7.tgz",
+      "integrity": "sha512-YZchteri2iUq5JICSH0BQjOU3ehE57+CMU8PBigcJZiaLa/GPiCuwD9QOsnwSzHJNYYx5C94uhtZUjPwUtIAIw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.6",
+        "@angular-devkit/core": "14.2.7",
         "rxjs": "6.6.7"
       },
       "dependencies": {
@@ -16192,15 +16192,15 @@
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.6.tgz",
-      "integrity": "sha512-XtaUwb3aZ8S0vl0y9bmbdFOH0KQCQ778twFH+ZfHW2BcPYtQz2Cy2rcVKXBQ850RyC0GxgMPfco6OGQndPpizg==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.7.tgz",
+      "integrity": "sha512-Y58kcEmy8bSFyODtUFQzkuoZHNCji3fzRwGCiQYdAh/mkBf53CuVWoT9q7MrvGOc7Nmo2JiuwR/b7c543eVgfw==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1402.6",
-        "@angular-devkit/build-webpack": "0.1402.6",
-        "@angular-devkit/core": "14.2.6",
+        "@angular-devkit/architect": "0.1402.7",
+        "@angular-devkit/build-webpack": "0.1402.7",
+        "@angular-devkit/core": "14.2.7",
         "@babel/core": "7.18.10",
         "@babel/generator": "7.18.12",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -16211,7 +16211,7 @@
         "@babel/runtime": "7.18.9",
         "@babel/template": "7.18.10",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "14.2.6",
+        "@ngtools/webpack": "14.2.7",
         "ansi-colors": "4.1.3",
         "babel-loader": "8.2.5",
         "babel-plugin-istanbul": "6.1.1",
@@ -16309,12 +16309,12 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1402.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.6.tgz",
-      "integrity": "sha512-gKsDxQ9pze0N1qDM0kdM4FfwpkjSOb0bQzqjZi7wTfrh/WGIQMCjG9CRwWT+Z289ZKaTpcQDPsDtOSo5QpKNDg==",
+      "version": "0.1402.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.7.tgz",
+      "integrity": "sha512-aDhS/ODt8BwgtnNN73R7SuMC1GgoT5Pajn1nnIWvvpGj8XchLUbguptyl2v7D2QeYXXsd34Gtx8cDOr9PxYFTA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1402.6",
+        "@angular-devkit/architect": "0.1402.7",
         "rxjs": "6.6.7"
       },
       "dependencies": {
@@ -16336,9 +16336,9 @@
       }
     },
     "@angular-devkit/core": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.6.tgz",
-      "integrity": "sha512-qtRSdRm/h7C3ya04PJTDgQXV6mM8Y4RakANX1GTSXetCf9AVSxg74NJX76DWUgiHT4JiPYnJgJU6Hr/L0H6JOQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.7.tgz",
+      "integrity": "sha512-83SCYP3h6fglWMgAXFDc8HfOxk9t3ugK0onATXchctvA7blW4Vx8BSg3/DgbqCv+fF380SN8bYqqLJl8fQFdzg==",
       "dev": true,
       "requires": {
         "ajv": "8.11.0",
@@ -16366,12 +16366,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.6.tgz",
-      "integrity": "sha512-mSFtc4M49mWrYsgJx/P6bA6SzXb8SeZqmppKRMoEQxiXI1bwFdGLNWzAmzEsGvS96h/nPIaOfcX5cKJSp++4FA==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.7.tgz",
+      "integrity": "sha512-3e2dpFXWl2Z4Gfm+KgY3gAeqsyu8utJMcDIg5sWRAXDeJJdAPc5LweCa8YZEn33Zr9cl8oK+FxlOr15RCyWLcA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.6",
+        "@angular-devkit/core": "14.2.7",
         "jsonc-parser": "3.1.0",
         "magic-string": "0.26.2",
         "ora": "5.4.1",
@@ -16474,15 +16474,15 @@
       }
     },
     "@angular/cli": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.6.tgz",
-      "integrity": "sha512-8tXpe3htfZY8a+Am4nluVcztMFD5wnx4edGEDkkOiqkrUzbCtX4AyEBjUFldsYKZXbRFU46xEfM6jBnLOjxDZQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.7.tgz",
+      "integrity": "sha512-RM4CJwtqD7cKFQ7hNGJ56s9YMeJxYqCN5Ss0SzsKN1nXYqz8HykMW8fhUbZQ9HFVy/Ml3LGoh1yGo/tXywAWcA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1402.6",
-        "@angular-devkit/core": "14.2.6",
-        "@angular-devkit/schematics": "14.2.6",
-        "@schematics/angular": "14.2.6",
+        "@angular-devkit/architect": "0.1402.7",
+        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/schematics": "14.2.7",
+        "@schematics/angular": "14.2.7",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "debug": "4.3.4",
@@ -16502,27 +16502,27 @@
       }
     },
     "@angular/common": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.7.tgz",
-      "integrity": "sha512-vfydeB8urLzhRnZev/1Zm87k9jWlNfhSTk09yUnqvzcORfd3xOkcei0qc1xdIHCTEMyTREC+umsYHDmlEpZsVw==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.8.tgz",
+      "integrity": "sha512-JSPN2h1EcyWjHWtOzRQmoX48ZacTjLAYwW9ZRmBpYs6Ptw5xZ39ARTJfQNcNnJleqYju2E6BNkGnLpbtWQjNDA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.7.tgz",
-      "integrity": "sha512-2I8hZVM/tfUi06B6VuWgf5hWu0tgNlMCEZ1Ed4NEDkqJj+gs2l6kNVUf+FxI6hHMZTFkJPXOPx3pI5Hea5CxEQ==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.8.tgz",
+      "integrity": "sha512-lKwp3B4ZKNLgk/25Iyur8bjAwRL20auRoB4EuHrBf+928ftsjYUXTgi+0++DUjPENbpi59k6GcvMCNa6qccvIw==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.7.tgz",
-      "integrity": "sha512-q6AQo91jc+Pd1PnWWxJq07IXr1yipq0MW3Uok5akEctbTsw4AT5y9wfPj6g/o/CkAz0kbL55QrmtyIWN5LMGdg==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.8.tgz",
+      "integrity": "sha512-QTftNrAyXOWzKFGY6/i9jh0LB2cOxmykepG4c53wH9LblGvWFztlVOhcoU8tpQSSH8t3EYvGs2r8oUuxcYm5Cw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.17.2",
@@ -16538,27 +16538,27 @@
       }
     },
     "@angular/core": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.7.tgz",
-      "integrity": "sha512-9u2eeKS90YPh2b0pK5LKFSxKfLIzHnzkIKQFh6bEPGj43Fl2v8CwiVJu1CAKo1Or4qBY8zspSowM6S1kgGwfeg==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.8.tgz",
+      "integrity": "sha512-cgnII9vJGJDLsfr7KsBfU2l+QQUmQIRIP3ImKhBxicw2IHKCSb2mYwoeLV46jaLyHyUMTLRHKUYUR4XtSPnb8A==",
       "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.7.tgz",
-      "integrity": "sha512-Hcn64kppozH5WlX/rkZoCGZyFFkLs0a4+rWen6uaZVxDWbas/PqR/a2LQerdS0Rn65/x+0l0w23u8TN0PnQPVA==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.8.tgz",
+      "integrity": "sha512-tSASBLXoBE0/Gt6d2nC6BJ1DvbGY5wo2Lb+8WCLSvkfsgVqOh4uRuJ2a0wwjeLFd0ZNmpjG42Ijba4btmCpIjg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.7.tgz",
-      "integrity": "sha512-P3c4fXH0+RDlL9uzuU5Xea5OQ3ozmoWawFtf4faH7fD3deHlNmrwROBXAlHkYRjbGcAiuxpEx6NjBGdmYWPaKg==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.8.tgz",
+      "integrity": "sha512-CPK8wHnKke8AUKR92XrFuanaKNXDzDm3uVI3DD0NxBo+fLAkiuVaDVIGgO6n6SxQVtwjXJtMXqQuNdzUg4Q9uQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
@@ -18075,9 +18075,9 @@
       "dev": true
     },
     "@ngtools/webpack": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.6.tgz",
-      "integrity": "sha512-HdfoHLGPzyP135BOlvTQcpeWisVfiH0u40YNTBVK3QAsrLnY17e2QG5BWBOrVYipRu1975cZtTC9rPjcCY8aLQ==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.7.tgz",
+      "integrity": "sha512-I47BdEybpzjfFFMFB691o9C+69RexLTgSm/VCyDn4M8DrGrZpgYNhxN+AEr1uA6Bi6MaPG6w+TMac5tNIaO4Yw==",
       "dev": true,
       "requires": {}
     },
@@ -18229,13 +18229,13 @@
       }
     },
     "@schematics/angular": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.6.tgz",
-      "integrity": "sha512-oeyMAQr3Q9nvAX+5FRgXcTMX9lqqenElBmAuwfqqdB0qD1jmkJ8TpWRuvYVA/931njpIwhfyLrzmzeNnJb23Sg==",
+      "version": "14.2.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.7.tgz",
+      "integrity": "sha512-ujtLu0gWARtJsRbN+P+McDO0Y0ygJjUN5016SdbmYDMcDJkwi+GYHU8Yvh/UONtmNor3JdV8AnZ8OmWTlswTDA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.6",
-        "@angular-devkit/schematics": "14.2.6",
+        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/schematics": "14.2.7",
         "jsonc-parser": "3.1.0"
       }
     },
@@ -23167,9 +23167,9 @@
       "dev": true
     },
     "memfs": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.7.tgz",
-      "integrity": "sha512-ygaiUSNalBX85388uskeCyhSAoOSgzBbtVCr9jA2RROssFL9Q19/ZXFqS+2Th2sr1ewNIWgFdLzLC3Yl1Zv+lw==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.9.tgz",
+      "integrity": "sha512-3rm8kbrzpUGRyPKSGuk387NZOwQ90O4rI9tsWQkzNW7BLSnKGp23RsEsKK8N8QVCrtJoAMqy3spxHC4os4G6PQ==",
       "dev": true,
       "requires": {
         "fs-monkey": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^14.2.7"
+    "@angular/core": "^14.2.8"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^14.2.6",
+    "@angular-devkit/build-angular": "^14.2.7",
     "@angular-eslint/builder": "^14.1.2",
     "@angular-eslint/eslint-plugin": "^14.1.2",
     "@angular-eslint/eslint-plugin-template": "^14.1.2",
     "@angular-eslint/schematics": "^14.1.2",
     "@angular-eslint/template-parser": "^14.1.2",
-    "@angular/cli": "^14.2.6",
-    "@angular/common": "^14.2.7",
-    "@angular/compiler": "^14.2.7",
-    "@angular/compiler-cli": "^14.2.7",
-    "@angular/platform-browser": "^14.2.7",
-    "@angular/platform-browser-dynamic": "^14.2.7",
+    "@angular/cli": "^14.2.7",
+    "@angular/common": "^14.2.8",
+    "@angular/compiler": "^14.2.8",
+    "@angular/compiler-cli": "^14.2.8",
+    "@angular/platform-browser": "^14.2.8",
+    "@angular/platform-browser-dynamic": "^14.2.8",
     "@types/jasmine": "^4.3.0",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^18.11.7",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            14.2.6 -> 14.2.7         ng update @angular/cli
      @angular/core                           14.2.7 -> 14.2.8         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>