### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^14.2.7",
+        "@angular-devkit/build-angular": "^14.2.8",
         "@angular-eslint/builder": "^14.1.2",
         "@angular-eslint/eslint-plugin": "^14.1.2",
         "@angular-eslint/eslint-plugin-template": "^14.1.2",
         "@angular-eslint/schematics": "^14.1.2",
         "@angular-eslint/template-parser": "^14.1.2",
-        "@angular/cli": "^14.2.7",
-        "@angular/common": "^14.2.8",
-        "@angular/compiler": "^14.2.8",
-        "@angular/compiler-cli": "^14.2.8",
-        "@angular/platform-browser": "^14.2.8",
-        "@angular/platform-browser-dynamic": "^14.2.8",
+        "@angular/cli": "^14.2.8",
+        "@angular/common": "^14.2.9",
+        "@angular/compiler": "^14.2.9",
+        "@angular/compiler-cli": "^14.2.9",
+        "@angular/platform-browser": "^14.2.9",
+        "@angular/platform-browser-dynamic": "^14.2.9",
         "@types/jasmine": "^4.3.0",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^18.11.9",
@@ -48,7 +48,7 @@
         "zone.js": "^0.11.8"
       },
       "peerDependencies": {
-        "@angular/core": "^14.2.8"
+        "@angular/core": "^14.2.9"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -70,12 +70,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1402.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.7.tgz",
-      "integrity": "sha512-YZchteri2iUq5JICSH0BQjOU3ehE57+CMU8PBigcJZiaLa/GPiCuwD9QOsnwSzHJNYYx5C94uhtZUjPwUtIAIw==",
+      "version": "0.1402.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.8.tgz",
+      "integrity": "sha512-z3HXPBi3h3y+D04NNA/5lVaUCMF+dkE/75bCqg4DG3FqV0i0dh4hozjKtWgX6xuoJ8AJlDfrJSaBCvjsog+Jhg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/core": "14.2.8",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -103,15 +103,15 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.7.tgz",
-      "integrity": "sha512-Y58kcEmy8bSFyODtUFQzkuoZHNCji3fzRwGCiQYdAh/mkBf53CuVWoT9q7MrvGOc7Nmo2JiuwR/b7c543eVgfw==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.8.tgz",
+      "integrity": "sha512-FSi7FHxqMLXmVulJg8ocGCTGbdnjPlQ0pSS91blg+PeL2Ly+h0hNl+MTLP/4aX9/n2SMPtcX7BbS20/M6UhoRw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1402.7",
-        "@angular-devkit/build-webpack": "0.1402.7",
-        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/architect": "0.1402.8",
+        "@angular-devkit/build-webpack": "0.1402.8",
+        "@angular-devkit/core": "14.2.8",
         "@babel/core": "7.18.10",
         "@babel/generator": "7.18.12",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -122,7 +122,7 @@
         "@babel/runtime": "7.18.9",
         "@babel/template": "7.18.10",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "14.2.7",
+        "@ngtools/webpack": "14.2.8",
         "ansi-colors": "4.1.3",
         "babel-loader": "8.2.5",
         "babel-plugin-istanbul": "6.1.1",
@@ -267,12 +267,12 @@
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1402.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.7.tgz",
-      "integrity": "sha512-aDhS/ODt8BwgtnNN73R7SuMC1GgoT5Pajn1nnIWvvpGj8XchLUbguptyl2v7D2QeYXXsd34Gtx8cDOr9PxYFTA==",
+      "version": "0.1402.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.8.tgz",
+      "integrity": "sha512-KBI6F44AMdOB+/pIAkVsxJYVnPVg+IkNBqug2oFOGnIab7VrFWpEEqihB1rAdRlMEjcPJ6YxNkzErDaOvtH2qw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1402.7",
+        "@angular-devkit/architect": "0.1402.8",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -304,9 +304,9 @@
       "dev": true
     },
     "node_modules/@angular-devkit/core": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.7.tgz",
-      "integrity": "sha512-83SCYP3h6fglWMgAXFDc8HfOxk9t3ugK0onATXchctvA7blW4Vx8BSg3/DgbqCv+fF380SN8bYqqLJl8fQFdzg==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.8.tgz",
+      "integrity": "sha512-30nDq2PH91X7T42xXFBlTiXTBG143z0BL8IUgpVCxTFYwxgPbtV4bcXTkiBgh1FL/usZcHa0Bd/64wxmFOpYwA==",
       "dev": true,
       "dependencies": {
         "ajv": "8.11.0",
@@ -348,12 +348,12 @@
       "dev": true
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.7.tgz",
-      "integrity": "sha512-3e2dpFXWl2Z4Gfm+KgY3gAeqsyu8utJMcDIg5sWRAXDeJJdAPc5LweCa8YZEn33Zr9cl8oK+FxlOr15RCyWLcA==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.8.tgz",
+      "integrity": "sha512-L5GEgueZV4vqZy9Ar0zxVJOHK/4ttF1nPjW4Ut1vRFJGxsHFVEpxq5eGBf2JYSiOhqmFYc6GnJOxA6C4xAIHjA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/core": "14.2.8",
         "jsonc-parser": "3.1.0",
         "magic-string": "0.26.2",
         "ora": "5.4.1",
@@ -486,15 +486,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.7.tgz",
-      "integrity": "sha512-RM4CJwtqD7cKFQ7hNGJ56s9YMeJxYqCN5Ss0SzsKN1nXYqz8HykMW8fhUbZQ9HFVy/Ml3LGoh1yGo/tXywAWcA==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.8.tgz",
+      "integrity": "sha512-yJDLSlTFwQhNJlFoXCw8r8iQWNJn9bIjBSdEL0mM9px5EvSxDYGDXwiJRvionlZAL9P4u0d8XeBy3EPyFkAE5Q==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1402.7",
-        "@angular-devkit/core": "14.2.7",
-        "@angular-devkit/schematics": "14.2.7",
-        "@schematics/angular": "14.2.7",
+        "@angular-devkit/architect": "0.1402.8",
+        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/schematics": "14.2.8",
+        "@schematics/angular": "14.2.8",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "debug": "4.3.4",
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.8.tgz",
-      "integrity": "sha512-JSPN2h1EcyWjHWtOzRQmoX48ZacTjLAYwW9ZRmBpYs6Ptw5xZ39ARTJfQNcNnJleqYju2E6BNkGnLpbtWQjNDA==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.9.tgz",
+      "integrity": "sha512-nC1He98gj4FQqSo31Fb9ZJ+Ao3jJbmAg1JAdF5L0tkY70YydM91HXAp/JDrJ12O7IomenAwEHONFCVxgUfqUJw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -533,14 +533,14 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "14.2.8",
+        "@angular/core": "14.2.9",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.8.tgz",
-      "integrity": "sha512-lKwp3B4ZKNLgk/25Iyur8bjAwRL20auRoB4EuHrBf+928ftsjYUXTgi+0++DUjPENbpi59k6GcvMCNa6qccvIw==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.9.tgz",
+      "integrity": "sha512-M0uYFMSAejYJ+fm/Lz1/l7nr1adVrYfC7lKBpbiyya5moGenRid81Fl7i2YY6RehFpGHw3GdPlMz+DRIMXgyuQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -549,7 +549,7 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "14.2.8"
+        "@angular/core": "14.2.9"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -558,9 +558,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.8.tgz",
-      "integrity": "sha512-QTftNrAyXOWzKFGY6/i9jh0LB2cOxmykepG4c53wH9LblGvWFztlVOhcoU8tpQSSH8t3EYvGs2r8oUuxcYm5Cw==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.9.tgz",
+      "integrity": "sha512-c3+LyW4WkZya4JnefUUOoCplwM9OgOnR2LqC6Qwro9Z40VXBqBeA5PJ6EJ28c4q6ZVoy5v00PwUVSwgcGP7qNA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.17.2",
@@ -583,14 +583,14 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "14.2.8",
+        "@angular/compiler": "14.2.9",
         "typescript": ">=4.6.2 <4.9"
       }
     },
     "node_modules/@angular/core": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.8.tgz",
-      "integrity": "sha512-cgnII9vJGJDLsfr7KsBfU2l+QQUmQIRIP3ImKhBxicw2IHKCSb2mYwoeLV46jaLyHyUMTLRHKUYUR4XtSPnb8A==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.9.tgz",
+      "integrity": "sha512-6bExQgGmN9qmBbVMl7WaZ1KFSfTgFK+MmLbvoh4a29b47h7wvEuUWO7ulczzoUJQfMGfXU/4ypEW1a8ZhX+Xrg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -604,9 +604,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.8.tgz",
-      "integrity": "sha512-tSASBLXoBE0/Gt6d2nC6BJ1DvbGY5wo2Lb+8WCLSvkfsgVqOh4uRuJ2a0wwjeLFd0ZNmpjG42Ijba4btmCpIjg==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.9.tgz",
+      "integrity": "sha512-cvKFyHZp69scDj+tOmknWsdyarpNjpuFHbn2Tn3K9HLJsNHOvP2g8d/KwHl5atRscnDK1ztNh+FUKhGmQZsbng==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -615,9 +615,9 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "14.2.8",
-        "@angular/common": "14.2.8",
-        "@angular/core": "14.2.8"
+        "@angular/animations": "14.2.9",
+        "@angular/common": "14.2.9",
+        "@angular/core": "14.2.9"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.8.tgz",
-      "integrity": "sha512-CPK8wHnKke8AUKR92XrFuanaKNXDzDm3uVI3DD0NxBo+fLAkiuVaDVIGgO6n6SxQVtwjXJtMXqQuNdzUg4Q9uQ==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.9.tgz",
+      "integrity": "sha512-hu0lfAkPplGhkQKXaryj+6wLboqIC8JNWGONlqKTaARgfaQ8TyMikOimKxMk9mljlJpPcrVxAewn5p9G0VmLng==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -637,10 +637,10 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "14.2.8",
-        "@angular/compiler": "14.2.8",
-        "@angular/core": "14.2.8",
-        "@angular/platform-browser": "14.2.8"
+        "@angular/common": "14.2.9",
+        "@angular/compiler": "14.2.9",
+        "@angular/core": "14.2.9",
+        "@angular/platform-browser": "14.2.9"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -2882,9 +2882,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.7.tgz",
-      "integrity": "sha512-I47BdEybpzjfFFMFB691o9C+69RexLTgSm/VCyDn4M8DrGrZpgYNhxN+AEr1uA6Bi6MaPG6w+TMac5tNIaO4Yw==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.8.tgz",
+      "integrity": "sha512-ugQRiOgQBbZUFSRRfj+KOUrtGHWI7IyVfnK3HA08+QFQOygY6igs07D6v4l5RHkUnyQkCgUE30EaFaj58fGJjg==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || >=16.10.0",
@@ -3112,13 +3112,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.7.tgz",
-      "integrity": "sha512-ujtLu0gWARtJsRbN+P+McDO0Y0ygJjUN5016SdbmYDMcDJkwi+GYHU8Yvh/UONtmNor3JdV8AnZ8OmWTlswTDA==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.8.tgz",
+      "integrity": "sha512-SuzeCpWHF9+8jey7WheM1Va0iyJrYAD88O2VT2x0NEF2PXEH63lV7BCBtE7kKurIAmXBbvTCsPyZuFKYJGDHFA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.7",
-        "@angular-devkit/schematics": "14.2.7",
+        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/schematics": "14.2.8",
         "jsonc-parser": "3.1.0"
       },
       "engines": {
@@ -10455,9 +10455,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.9.tgz",
-      "integrity": "sha512-3rm8kbrzpUGRyPKSGuk387NZOwQ90O4rI9tsWQkzNW7BLSnKGp23RsEsKK8N8QVCrtJoAMqy3spxHC4os4G6PQ==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.10.tgz",
+      "integrity": "sha512-0bCUP+L79P4am30yP1msPzApwuMQG23TjwlwdHeEV5MxioDR1a0AgB0T9FfggU52eJuDCq8WVwb5ekznFyWiTQ==",
       "dev": true,
       "dependencies": {
         "fs-monkey": "^1.0.3"
@@ -16172,12 +16172,12 @@
       }
     },
     "@angular-devkit/architect": {
-      "version": "0.1402.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.7.tgz",
-      "integrity": "sha512-YZchteri2iUq5JICSH0BQjOU3ehE57+CMU8PBigcJZiaLa/GPiCuwD9QOsnwSzHJNYYx5C94uhtZUjPwUtIAIw==",
+      "version": "0.1402.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.8.tgz",
+      "integrity": "sha512-z3HXPBi3h3y+D04NNA/5lVaUCMF+dkE/75bCqg4DG3FqV0i0dh4hozjKtWgX6xuoJ8AJlDfrJSaBCvjsog+Jhg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/core": "14.2.8",
         "rxjs": "6.6.7"
       },
       "dependencies": {
@@ -16199,15 +16199,15 @@
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.7.tgz",
-      "integrity": "sha512-Y58kcEmy8bSFyODtUFQzkuoZHNCji3fzRwGCiQYdAh/mkBf53CuVWoT9q7MrvGOc7Nmo2JiuwR/b7c543eVgfw==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.8.tgz",
+      "integrity": "sha512-FSi7FHxqMLXmVulJg8ocGCTGbdnjPlQ0pSS91blg+PeL2Ly+h0hNl+MTLP/4aX9/n2SMPtcX7BbS20/M6UhoRw==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1402.7",
-        "@angular-devkit/build-webpack": "0.1402.7",
-        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/architect": "0.1402.8",
+        "@angular-devkit/build-webpack": "0.1402.8",
+        "@angular-devkit/core": "14.2.8",
         "@babel/core": "7.18.10",
         "@babel/generator": "7.18.12",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -16218,7 +16218,7 @@
         "@babel/runtime": "7.18.9",
         "@babel/template": "7.18.10",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "14.2.7",
+        "@ngtools/webpack": "14.2.8",
         "ansi-colors": "4.1.3",
         "babel-loader": "8.2.5",
         "babel-plugin-istanbul": "6.1.1",
@@ -16316,12 +16316,12 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1402.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.7.tgz",
-      "integrity": "sha512-aDhS/ODt8BwgtnNN73R7SuMC1GgoT5Pajn1nnIWvvpGj8XchLUbguptyl2v7D2QeYXXsd34Gtx8cDOr9PxYFTA==",
+      "version": "0.1402.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.8.tgz",
+      "integrity": "sha512-KBI6F44AMdOB+/pIAkVsxJYVnPVg+IkNBqug2oFOGnIab7VrFWpEEqihB1rAdRlMEjcPJ6YxNkzErDaOvtH2qw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1402.7",
+        "@angular-devkit/architect": "0.1402.8",
         "rxjs": "6.6.7"
       },
       "dependencies": {
@@ -16343,9 +16343,9 @@
       }
     },
     "@angular-devkit/core": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.7.tgz",
-      "integrity": "sha512-83SCYP3h6fglWMgAXFDc8HfOxk9t3ugK0onATXchctvA7blW4Vx8BSg3/DgbqCv+fF380SN8bYqqLJl8fQFdzg==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.8.tgz",
+      "integrity": "sha512-30nDq2PH91X7T42xXFBlTiXTBG143z0BL8IUgpVCxTFYwxgPbtV4bcXTkiBgh1FL/usZcHa0Bd/64wxmFOpYwA==",
       "dev": true,
       "requires": {
         "ajv": "8.11.0",
@@ -16373,12 +16373,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.7.tgz",
-      "integrity": "sha512-3e2dpFXWl2Z4Gfm+KgY3gAeqsyu8utJMcDIg5sWRAXDeJJdAPc5LweCa8YZEn33Zr9cl8oK+FxlOr15RCyWLcA==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.8.tgz",
+      "integrity": "sha512-L5GEgueZV4vqZy9Ar0zxVJOHK/4ttF1nPjW4Ut1vRFJGxsHFVEpxq5eGBf2JYSiOhqmFYc6GnJOxA6C4xAIHjA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.7",
+        "@angular-devkit/core": "14.2.8",
         "jsonc-parser": "3.1.0",
         "magic-string": "0.26.2",
         "ora": "5.4.1",
@@ -16481,15 +16481,15 @@
       }
     },
     "@angular/cli": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.7.tgz",
-      "integrity": "sha512-RM4CJwtqD7cKFQ7hNGJ56s9YMeJxYqCN5Ss0SzsKN1nXYqz8HykMW8fhUbZQ9HFVy/Ml3LGoh1yGo/tXywAWcA==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.8.tgz",
+      "integrity": "sha512-yJDLSlTFwQhNJlFoXCw8r8iQWNJn9bIjBSdEL0mM9px5EvSxDYGDXwiJRvionlZAL9P4u0d8XeBy3EPyFkAE5Q==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1402.7",
-        "@angular-devkit/core": "14.2.7",
-        "@angular-devkit/schematics": "14.2.7",
-        "@schematics/angular": "14.2.7",
+        "@angular-devkit/architect": "0.1402.8",
+        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/schematics": "14.2.8",
+        "@schematics/angular": "14.2.8",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "debug": "4.3.4",
@@ -16509,27 +16509,27 @@
       }
     },
     "@angular/common": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.8.tgz",
-      "integrity": "sha512-JSPN2h1EcyWjHWtOzRQmoX48ZacTjLAYwW9ZRmBpYs6Ptw5xZ39ARTJfQNcNnJleqYju2E6BNkGnLpbtWQjNDA==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.9.tgz",
+      "integrity": "sha512-nC1He98gj4FQqSo31Fb9ZJ+Ao3jJbmAg1JAdF5L0tkY70YydM91HXAp/JDrJ12O7IomenAwEHONFCVxgUfqUJw==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.8.tgz",
-      "integrity": "sha512-lKwp3B4ZKNLgk/25Iyur8bjAwRL20auRoB4EuHrBf+928ftsjYUXTgi+0++DUjPENbpi59k6GcvMCNa6qccvIw==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.9.tgz",
+      "integrity": "sha512-M0uYFMSAejYJ+fm/Lz1/l7nr1adVrYfC7lKBpbiyya5moGenRid81Fl7i2YY6RehFpGHw3GdPlMz+DRIMXgyuQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.8.tgz",
-      "integrity": "sha512-QTftNrAyXOWzKFGY6/i9jh0LB2cOxmykepG4c53wH9LblGvWFztlVOhcoU8tpQSSH8t3EYvGs2r8oUuxcYm5Cw==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.9.tgz",
+      "integrity": "sha512-c3+LyW4WkZya4JnefUUOoCplwM9OgOnR2LqC6Qwro9Z40VXBqBeA5PJ6EJ28c4q6ZVoy5v00PwUVSwgcGP7qNA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.17.2",
@@ -16545,27 +16545,27 @@
       }
     },
     "@angular/core": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.8.tgz",
-      "integrity": "sha512-cgnII9vJGJDLsfr7KsBfU2l+QQUmQIRIP3ImKhBxicw2IHKCSb2mYwoeLV46jaLyHyUMTLRHKUYUR4XtSPnb8A==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.9.tgz",
+      "integrity": "sha512-6bExQgGmN9qmBbVMl7WaZ1KFSfTgFK+MmLbvoh4a29b47h7wvEuUWO7ulczzoUJQfMGfXU/4ypEW1a8ZhX+Xrg==",
       "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.8.tgz",
-      "integrity": "sha512-tSASBLXoBE0/Gt6d2nC6BJ1DvbGY5wo2Lb+8WCLSvkfsgVqOh4uRuJ2a0wwjeLFd0ZNmpjG42Ijba4btmCpIjg==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.9.tgz",
+      "integrity": "sha512-cvKFyHZp69scDj+tOmknWsdyarpNjpuFHbn2Tn3K9HLJsNHOvP2g8d/KwHl5atRscnDK1ztNh+FUKhGmQZsbng==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.8.tgz",
-      "integrity": "sha512-CPK8wHnKke8AUKR92XrFuanaKNXDzDm3uVI3DD0NxBo+fLAkiuVaDVIGgO6n6SxQVtwjXJtMXqQuNdzUg4Q9uQ==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.9.tgz",
+      "integrity": "sha512-hu0lfAkPplGhkQKXaryj+6wLboqIC8JNWGONlqKTaARgfaQ8TyMikOimKxMk9mljlJpPcrVxAewn5p9G0VmLng==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
@@ -18082,9 +18082,9 @@
       "dev": true
     },
     "@ngtools/webpack": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.7.tgz",
-      "integrity": "sha512-I47BdEybpzjfFFMFB691o9C+69RexLTgSm/VCyDn4M8DrGrZpgYNhxN+AEr1uA6Bi6MaPG6w+TMac5tNIaO4Yw==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.8.tgz",
+      "integrity": "sha512-ugQRiOgQBbZUFSRRfj+KOUrtGHWI7IyVfnK3HA08+QFQOygY6igs07D6v4l5RHkUnyQkCgUE30EaFaj58fGJjg==",
       "dev": true,
       "requires": {}
     },
@@ -18236,13 +18236,13 @@
       }
     },
     "@schematics/angular": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.7.tgz",
-      "integrity": "sha512-ujtLu0gWARtJsRbN+P+McDO0Y0ygJjUN5016SdbmYDMcDJkwi+GYHU8Yvh/UONtmNor3JdV8AnZ8OmWTlswTDA==",
+      "version": "14.2.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.8.tgz",
+      "integrity": "sha512-SuzeCpWHF9+8jey7WheM1Va0iyJrYAD88O2VT2x0NEF2PXEH63lV7BCBtE7kKurIAmXBbvTCsPyZuFKYJGDHFA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.7",
-        "@angular-devkit/schematics": "14.2.7",
+        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/schematics": "14.2.8",
         "jsonc-parser": "3.1.0"
       }
     },
@@ -23175,9 +23175,9 @@
       "dev": true
     },
     "memfs": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.9.tgz",
-      "integrity": "sha512-3rm8kbrzpUGRyPKSGuk387NZOwQ90O4rI9tsWQkzNW7BLSnKGp23RsEsKK8N8QVCrtJoAMqy3spxHC4os4G6PQ==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.10.tgz",
+      "integrity": "sha512-0bCUP+L79P4am30yP1msPzApwuMQG23TjwlwdHeEV5MxioDR1a0AgB0T9FfggU52eJuDCq8WVwb5ekznFyWiTQ==",
       "dev": true,
       "requires": {
         "fs-monkey": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^14.2.8"
+    "@angular/core": "^14.2.9"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^14.2.7",
+    "@angular-devkit/build-angular": "^14.2.8",
     "@angular-eslint/builder": "^14.1.2",
     "@angular-eslint/eslint-plugin": "^14.1.2",
     "@angular-eslint/eslint-plugin-template": "^14.1.2",
     "@angular-eslint/schematics": "^14.1.2",
     "@angular-eslint/template-parser": "^14.1.2",
-    "@angular/cli": "^14.2.7",
-    "@angular/common": "^14.2.8",
-    "@angular/compiler": "^14.2.8",
-    "@angular/compiler-cli": "^14.2.8",
-    "@angular/platform-browser": "^14.2.8",
-    "@angular/platform-browser-dynamic": "^14.2.8",
+    "@angular/cli": "^14.2.8",
+    "@angular/common": "^14.2.9",
+    "@angular/compiler": "^14.2.9",
+    "@angular/compiler-cli": "^14.2.9",
+    "@angular/platform-browser": "^14.2.9",
+    "@angular/platform-browser-dynamic": "^14.2.9",
     "@types/jasmine": "^4.3.0",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^18.11.9",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            14.2.7 -> 14.2.8         ng update @angular/cli
      @angular/core                           14.2.8 -> 14.2.9         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>