### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^14.2.8",
+        "@angular-devkit/build-angular": "^14.2.9",
         "@angular-eslint/builder": "^14.1.2",
         "@angular-eslint/eslint-plugin": "^14.1.2",
         "@angular-eslint/eslint-plugin-template": "^14.1.2",
         "@angular-eslint/schematics": "^14.1.2",
         "@angular-eslint/template-parser": "^14.1.2",
-        "@angular/cli": "^14.2.8",
-        "@angular/common": "^14.2.9",
-        "@angular/compiler": "^14.2.9",
-        "@angular/compiler-cli": "^14.2.9",
-        "@angular/platform-browser": "^14.2.9",
-        "@angular/platform-browser-dynamic": "^14.2.9",
+        "@angular/cli": "^14.2.9",
+        "@angular/common": "^14.2.10",
+        "@angular/compiler": "^14.2.10",
+        "@angular/compiler-cli": "^14.2.10",
+        "@angular/platform-browser": "^14.2.10",
+        "@angular/platform-browser-dynamic": "^14.2.10",
         "@types/jasmine": "^4.3.0",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^18.11.9",
@@ -48,7 +48,7 @@
         "zone.js": "^0.11.8"
       },
       "peerDependencies": {
-        "@angular/core": "^14.2.9"
+        "@angular/core": "^14.2.10"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -70,12 +70,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1402.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.8.tgz",
-      "integrity": "sha512-z3HXPBi3h3y+D04NNA/5lVaUCMF+dkE/75bCqg4DG3FqV0i0dh4hozjKtWgX6xuoJ8AJlDfrJSaBCvjsog+Jhg==",
+      "version": "0.1402.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.9.tgz",
+      "integrity": "sha512-I0KTpmtukxq447CkdzKonFpIytRnvC77WuwnX4Sef32EM9KqmeNvfy/gZwm08Lqi4mOAC/iTCajXH1TN/4xllA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/core": "14.2.9",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -103,15 +103,15 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.8.tgz",
-      "integrity": "sha512-FSi7FHxqMLXmVulJg8ocGCTGbdnjPlQ0pSS91blg+PeL2Ly+h0hNl+MTLP/4aX9/n2SMPtcX7BbS20/M6UhoRw==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.9.tgz",
+      "integrity": "sha512-/6ul4JLpiKLB4+PJzDF7twgZf28GNHxxJKsheymrxC+ZRMGoMsJCzoU/dmOXE2YY8yGxAFnrTAVIJYomn+QnZQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1402.8",
-        "@angular-devkit/build-webpack": "0.1402.8",
-        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/architect": "0.1402.9",
+        "@angular-devkit/build-webpack": "0.1402.9",
+        "@angular-devkit/core": "14.2.9",
         "@babel/core": "7.18.10",
         "@babel/generator": "7.18.12",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -122,7 +122,7 @@
         "@babel/runtime": "7.18.9",
         "@babel/template": "7.18.10",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "14.2.8",
+        "@ngtools/webpack": "14.2.9",
         "ansi-colors": "4.1.3",
         "babel-loader": "8.2.5",
         "babel-plugin-istanbul": "6.1.1",
@@ -267,12 +267,12 @@
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1402.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.8.tgz",
-      "integrity": "sha512-KBI6F44AMdOB+/pIAkVsxJYVnPVg+IkNBqug2oFOGnIab7VrFWpEEqihB1rAdRlMEjcPJ6YxNkzErDaOvtH2qw==",
+      "version": "0.1402.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.9.tgz",
+      "integrity": "sha512-J+bseVpEqHAfxvTKYNoo6B+5TmnkQmEn9aNMEiQ+hv8pQyuW3DCWZ6jOQrfCpJzCYMBdrQALfaRpsQuB92UPVw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1402.8",
+        "@angular-devkit/architect": "0.1402.9",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -304,9 +304,9 @@
       "dev": true
     },
     "node_modules/@angular-devkit/core": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.8.tgz",
-      "integrity": "sha512-30nDq2PH91X7T42xXFBlTiXTBG143z0BL8IUgpVCxTFYwxgPbtV4bcXTkiBgh1FL/usZcHa0Bd/64wxmFOpYwA==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.9.tgz",
+      "integrity": "sha512-+e2OmzH/0gjNNH96xJDgshbuIM/NPSwE0NQlgU/KRb8TZt+7ooTmZJ1vk25HKV2YS99BEYzUSqvVAaJtxX/6Qw==",
       "dev": true,
       "dependencies": {
         "ajv": "8.11.0",
@@ -348,12 +348,12 @@
       "dev": true
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.8.tgz",
-      "integrity": "sha512-L5GEgueZV4vqZy9Ar0zxVJOHK/4ttF1nPjW4Ut1vRFJGxsHFVEpxq5eGBf2JYSiOhqmFYc6GnJOxA6C4xAIHjA==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.9.tgz",
+      "integrity": "sha512-E7muTIbDqysjQld5r9AGXiW8vKHadkHaGe+0QONpmr8TMAtTMqBFxBXRG9vajiUzt/GcFL9dbGGEwM/1dc7VPQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/core": "14.2.9",
         "jsonc-parser": "3.1.0",
         "magic-string": "0.26.2",
         "ora": "5.4.1",
@@ -486,15 +486,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.8.tgz",
-      "integrity": "sha512-yJDLSlTFwQhNJlFoXCw8r8iQWNJn9bIjBSdEL0mM9px5EvSxDYGDXwiJRvionlZAL9P4u0d8XeBy3EPyFkAE5Q==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.9.tgz",
+      "integrity": "sha512-1cQE7mRrPyzk1sg2UwpbQ/sXQyPukPKdN69o4Bn59Scfl/4wUh53WRPAAHXNudgPYT2ZT3s9Jj2E1cdhi+gxyQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1402.8",
-        "@angular-devkit/core": "14.2.8",
-        "@angular-devkit/schematics": "14.2.8",
-        "@schematics/angular": "14.2.8",
+        "@angular-devkit/architect": "0.1402.9",
+        "@angular-devkit/core": "14.2.9",
+        "@angular-devkit/schematics": "14.2.9",
+        "@schematics/angular": "14.2.9",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "debug": "4.3.4",
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.9.tgz",
-      "integrity": "sha512-nC1He98gj4FQqSo31Fb9ZJ+Ao3jJbmAg1JAdF5L0tkY70YydM91HXAp/JDrJ12O7IomenAwEHONFCVxgUfqUJw==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.10.tgz",
+      "integrity": "sha512-uXtopPVKq1in/wcyMUYNk9uVDJ1ArlZ0wkfZEE1EMFaIZXR4p1fkbH1zMukUK+ldRlyqkuT1btZUq15incsKcg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -533,14 +533,14 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "14.2.9",
+        "@angular/core": "14.2.10",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.9.tgz",
-      "integrity": "sha512-M0uYFMSAejYJ+fm/Lz1/l7nr1adVrYfC7lKBpbiyya5moGenRid81Fl7i2YY6RehFpGHw3GdPlMz+DRIMXgyuQ==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.10.tgz",
+      "integrity": "sha512-CvZTJNKCNqU3Lr0La60U3XXZfpQbba/eb5YWTgygpoP0kjwOcNOsVou9TrGm57hT5ODy8281JOjWTrKspmYt5w==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -549,7 +549,7 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "14.2.9"
+        "@angular/core": "14.2.10"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -558,9 +558,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.9.tgz",
-      "integrity": "sha512-c3+LyW4WkZya4JnefUUOoCplwM9OgOnR2LqC6Qwro9Z40VXBqBeA5PJ6EJ28c4q6ZVoy5v00PwUVSwgcGP7qNA==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.10.tgz",
+      "integrity": "sha512-1GY1jdHqMpTBapjb0l61vQp0kPo9fryltOwQdm+zElODVFQWl/kvtq1VuMPr+E2qMfNSYg+ffrSixN7nG/E2ww==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.17.2",
@@ -583,14 +583,14 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "14.2.9",
+        "@angular/compiler": "14.2.10",
         "typescript": ">=4.6.2 <4.9"
       }
     },
     "node_modules/@angular/core": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.9.tgz",
-      "integrity": "sha512-6bExQgGmN9qmBbVMl7WaZ1KFSfTgFK+MmLbvoh4a29b47h7wvEuUWO7ulczzoUJQfMGfXU/4ypEW1a8ZhX+Xrg==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.10.tgz",
+      "integrity": "sha512-3XN+c0+tAtcUc8o7sQ41RLcSFPMt8krCfKFpDUOQwKjm90OOBcoG0LfmRfYBFNAenQh4glQQGOaYvLY98bTFTw==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -600,13 +600,13 @@
       },
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
-        "zone.js": "~0.11.4"
+        "zone.js": "~0.11.4 || ~0.12.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.9.tgz",
-      "integrity": "sha512-cvKFyHZp69scDj+tOmknWsdyarpNjpuFHbn2Tn3K9HLJsNHOvP2g8d/KwHl5atRscnDK1ztNh+FUKhGmQZsbng==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.10.tgz",
+      "integrity": "sha512-oYd5UMuGt4bocGFEaNYhQ7vzZFygLzCVM+SYxgfOHcgzeofZOjdaZgb84ANKgca5jguZg2ZGo1iklAbvfMrk2A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -615,9 +615,9 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "14.2.9",
-        "@angular/common": "14.2.9",
-        "@angular/core": "14.2.9"
+        "@angular/animations": "14.2.10",
+        "@angular/common": "14.2.10",
+        "@angular/core": "14.2.10"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.9.tgz",
-      "integrity": "sha512-hu0lfAkPplGhkQKXaryj+6wLboqIC8JNWGONlqKTaARgfaQ8TyMikOimKxMk9mljlJpPcrVxAewn5p9G0VmLng==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.10.tgz",
+      "integrity": "sha512-K6hCCECGtjLsx9+fNOR7nx6oIqyIlLQnpv/u/L4bw/gL5Usr6t6R15lu0Rg+AT2MxDX1ELG7BG0ZKalLjSaquw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -637,10 +637,10 @@
         "node": "^14.15.0 || >=16.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "14.2.9",
-        "@angular/compiler": "14.2.9",
-        "@angular/core": "14.2.9",
-        "@angular/platform-browser": "14.2.9"
+        "@angular/common": "14.2.10",
+        "@angular/compiler": "14.2.10",
+        "@angular/core": "14.2.10",
+        "@angular/platform-browser": "14.2.10"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -2882,9 +2882,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.8.tgz",
-      "integrity": "sha512-ugQRiOgQBbZUFSRRfj+KOUrtGHWI7IyVfnK3HA08+QFQOygY6igs07D6v4l5RHkUnyQkCgUE30EaFaj58fGJjg==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.9.tgz",
+      "integrity": "sha512-P2zgvsfSpN4BkNzZWnPKUVOzv3y/SUWdnx/nhAG5gsQkLBp0Vf2evwQnbPUKuCrbMpYd1V/5SHb48+0B6FbUtQ==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || >=16.10.0",
@@ -3112,13 +3112,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.8.tgz",
-      "integrity": "sha512-SuzeCpWHF9+8jey7WheM1Va0iyJrYAD88O2VT2x0NEF2PXEH63lV7BCBtE7kKurIAmXBbvTCsPyZuFKYJGDHFA==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.9.tgz",
+      "integrity": "sha512-pt/eN+D9a6JeOjgqEdWP8lU6VQIoo3F8RcoVEVXHhjXzF2mIe1a3ZJTwY3ssdemKV4mZgseTJBG99/jxrHK0XQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.8",
-        "@angular-devkit/schematics": "14.2.8",
+        "@angular-devkit/core": "14.2.9",
+        "@angular-devkit/schematics": "14.2.9",
         "jsonc-parser": "3.1.0"
       },
       "engines": {
@@ -10458,9 +10458,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.10.tgz",
-      "integrity": "sha512-0bCUP+L79P4am30yP1msPzApwuMQG23TjwlwdHeEV5MxioDR1a0AgB0T9FfggU52eJuDCq8WVwb5ekznFyWiTQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.11.tgz",
+      "integrity": "sha512-GvsCITGAyDCxxsJ+X6prJexFQEhOCJaIlUbsAvjzSI5o5O7j2dle3jWvz5Z5aOdpOxW6ol3vI1+0ut+641F1+w==",
       "dev": true,
       "dependencies": {
         "fs-monkey": "^1.0.3"
@@ -16176,12 +16176,12 @@
       }
     },
     "@angular-devkit/architect": {
-      "version": "0.1402.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.8.tgz",
-      "integrity": "sha512-z3HXPBi3h3y+D04NNA/5lVaUCMF+dkE/75bCqg4DG3FqV0i0dh4hozjKtWgX6xuoJ8AJlDfrJSaBCvjsog+Jhg==",
+      "version": "0.1402.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.9.tgz",
+      "integrity": "sha512-I0KTpmtukxq447CkdzKonFpIytRnvC77WuwnX4Sef32EM9KqmeNvfy/gZwm08Lqi4mOAC/iTCajXH1TN/4xllA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/core": "14.2.9",
         "rxjs": "6.6.7"
       },
       "dependencies": {
@@ -16203,15 +16203,15 @@
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.8.tgz",
-      "integrity": "sha512-FSi7FHxqMLXmVulJg8ocGCTGbdnjPlQ0pSS91blg+PeL2Ly+h0hNl+MTLP/4aX9/n2SMPtcX7BbS20/M6UhoRw==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-14.2.9.tgz",
+      "integrity": "sha512-/6ul4JLpiKLB4+PJzDF7twgZf28GNHxxJKsheymrxC+ZRMGoMsJCzoU/dmOXE2YY8yGxAFnrTAVIJYomn+QnZQ==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1402.8",
-        "@angular-devkit/build-webpack": "0.1402.8",
-        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/architect": "0.1402.9",
+        "@angular-devkit/build-webpack": "0.1402.9",
+        "@angular-devkit/core": "14.2.9",
         "@babel/core": "7.18.10",
         "@babel/generator": "7.18.12",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -16222,7 +16222,7 @@
         "@babel/runtime": "7.18.9",
         "@babel/template": "7.18.10",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "14.2.8",
+        "@ngtools/webpack": "14.2.9",
         "ansi-colors": "4.1.3",
         "babel-loader": "8.2.5",
         "babel-plugin-istanbul": "6.1.1",
@@ -16320,12 +16320,12 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1402.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.8.tgz",
-      "integrity": "sha512-KBI6F44AMdOB+/pIAkVsxJYVnPVg+IkNBqug2oFOGnIab7VrFWpEEqihB1rAdRlMEjcPJ6YxNkzErDaOvtH2qw==",
+      "version": "0.1402.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1402.9.tgz",
+      "integrity": "sha512-J+bseVpEqHAfxvTKYNoo6B+5TmnkQmEn9aNMEiQ+hv8pQyuW3DCWZ6jOQrfCpJzCYMBdrQALfaRpsQuB92UPVw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1402.8",
+        "@angular-devkit/architect": "0.1402.9",
         "rxjs": "6.6.7"
       },
       "dependencies": {
@@ -16347,9 +16347,9 @@
       }
     },
     "@angular-devkit/core": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.8.tgz",
-      "integrity": "sha512-30nDq2PH91X7T42xXFBlTiXTBG143z0BL8IUgpVCxTFYwxgPbtV4bcXTkiBgh1FL/usZcHa0Bd/64wxmFOpYwA==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.9.tgz",
+      "integrity": "sha512-+e2OmzH/0gjNNH96xJDgshbuIM/NPSwE0NQlgU/KRb8TZt+7ooTmZJ1vk25HKV2YS99BEYzUSqvVAaJtxX/6Qw==",
       "dev": true,
       "requires": {
         "ajv": "8.11.0",
@@ -16377,12 +16377,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.8.tgz",
-      "integrity": "sha512-L5GEgueZV4vqZy9Ar0zxVJOHK/4ttF1nPjW4Ut1vRFJGxsHFVEpxq5eGBf2JYSiOhqmFYc6GnJOxA6C4xAIHjA==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.9.tgz",
+      "integrity": "sha512-E7muTIbDqysjQld5r9AGXiW8vKHadkHaGe+0QONpmr8TMAtTMqBFxBXRG9vajiUzt/GcFL9dbGGEwM/1dc7VPQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.8",
+        "@angular-devkit/core": "14.2.9",
         "jsonc-parser": "3.1.0",
         "magic-string": "0.26.2",
         "ora": "5.4.1",
@@ -16485,15 +16485,15 @@
       }
     },
     "@angular/cli": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.8.tgz",
-      "integrity": "sha512-yJDLSlTFwQhNJlFoXCw8r8iQWNJn9bIjBSdEL0mM9px5EvSxDYGDXwiJRvionlZAL9P4u0d8XeBy3EPyFkAE5Q==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.9.tgz",
+      "integrity": "sha512-1cQE7mRrPyzk1sg2UwpbQ/sXQyPukPKdN69o4Bn59Scfl/4wUh53WRPAAHXNudgPYT2ZT3s9Jj2E1cdhi+gxyQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1402.8",
-        "@angular-devkit/core": "14.2.8",
-        "@angular-devkit/schematics": "14.2.8",
-        "@schematics/angular": "14.2.8",
+        "@angular-devkit/architect": "0.1402.9",
+        "@angular-devkit/core": "14.2.9",
+        "@angular-devkit/schematics": "14.2.9",
+        "@schematics/angular": "14.2.9",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "debug": "4.3.4",
@@ -16513,27 +16513,27 @@
       }
     },
     "@angular/common": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.9.tgz",
-      "integrity": "sha512-nC1He98gj4FQqSo31Fb9ZJ+Ao3jJbmAg1JAdF5L0tkY70YydM91HXAp/JDrJ12O7IomenAwEHONFCVxgUfqUJw==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.10.tgz",
+      "integrity": "sha512-uXtopPVKq1in/wcyMUYNk9uVDJ1ArlZ0wkfZEE1EMFaIZXR4p1fkbH1zMukUK+ldRlyqkuT1btZUq15incsKcg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.9.tgz",
-      "integrity": "sha512-M0uYFMSAejYJ+fm/Lz1/l7nr1adVrYfC7lKBpbiyya5moGenRid81Fl7i2YY6RehFpGHw3GdPlMz+DRIMXgyuQ==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.2.10.tgz",
+      "integrity": "sha512-CvZTJNKCNqU3Lr0La60U3XXZfpQbba/eb5YWTgygpoP0kjwOcNOsVou9TrGm57hT5ODy8281JOjWTrKspmYt5w==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.9.tgz",
-      "integrity": "sha512-c3+LyW4WkZya4JnefUUOoCplwM9OgOnR2LqC6Qwro9Z40VXBqBeA5PJ6EJ28c4q6ZVoy5v00PwUVSwgcGP7qNA==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.2.10.tgz",
+      "integrity": "sha512-1GY1jdHqMpTBapjb0l61vQp0kPo9fryltOwQdm+zElODVFQWl/kvtq1VuMPr+E2qMfNSYg+ffrSixN7nG/E2ww==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.17.2",
@@ -16549,27 +16549,27 @@
       }
     },
     "@angular/core": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.9.tgz",
-      "integrity": "sha512-6bExQgGmN9qmBbVMl7WaZ1KFSfTgFK+MmLbvoh4a29b47h7wvEuUWO7ulczzoUJQfMGfXU/4ypEW1a8ZhX+Xrg==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.10.tgz",
+      "integrity": "sha512-3XN+c0+tAtcUc8o7sQ41RLcSFPMt8krCfKFpDUOQwKjm90OOBcoG0LfmRfYBFNAenQh4glQQGOaYvLY98bTFTw==",
       "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.9.tgz",
-      "integrity": "sha512-cvKFyHZp69scDj+tOmknWsdyarpNjpuFHbn2Tn3K9HLJsNHOvP2g8d/KwHl5atRscnDK1ztNh+FUKhGmQZsbng==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.2.10.tgz",
+      "integrity": "sha512-oYd5UMuGt4bocGFEaNYhQ7vzZFygLzCVM+SYxgfOHcgzeofZOjdaZgb84ANKgca5jguZg2ZGo1iklAbvfMrk2A==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.9.tgz",
-      "integrity": "sha512-hu0lfAkPplGhkQKXaryj+6wLboqIC8JNWGONlqKTaARgfaQ8TyMikOimKxMk9mljlJpPcrVxAewn5p9G0VmLng==",
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.2.10.tgz",
+      "integrity": "sha512-K6hCCECGtjLsx9+fNOR7nx6oIqyIlLQnpv/u/L4bw/gL5Usr6t6R15lu0Rg+AT2MxDX1ELG7BG0ZKalLjSaquw==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
@@ -18086,9 +18086,9 @@
       "dev": true
     },
     "@ngtools/webpack": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.8.tgz",
-      "integrity": "sha512-ugQRiOgQBbZUFSRRfj+KOUrtGHWI7IyVfnK3HA08+QFQOygY6igs07D6v4l5RHkUnyQkCgUE30EaFaj58fGJjg==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.9.tgz",
+      "integrity": "sha512-P2zgvsfSpN4BkNzZWnPKUVOzv3y/SUWdnx/nhAG5gsQkLBp0Vf2evwQnbPUKuCrbMpYd1V/5SHb48+0B6FbUtQ==",
       "dev": true,
       "requires": {}
     },
@@ -18240,13 +18240,13 @@
       }
     },
     "@schematics/angular": {
-      "version": "14.2.8",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.8.tgz",
-      "integrity": "sha512-SuzeCpWHF9+8jey7WheM1Va0iyJrYAD88O2VT2x0NEF2PXEH63lV7BCBtE7kKurIAmXBbvTCsPyZuFKYJGDHFA==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.9.tgz",
+      "integrity": "sha512-pt/eN+D9a6JeOjgqEdWP8lU6VQIoo3F8RcoVEVXHhjXzF2mIe1a3ZJTwY3ssdemKV4mZgseTJBG99/jxrHK0XQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.8",
-        "@angular-devkit/schematics": "14.2.8",
+        "@angular-devkit/core": "14.2.9",
+        "@angular-devkit/schematics": "14.2.9",
         "jsonc-parser": "3.1.0"
       }
     },
@@ -23185,9 +23185,9 @@
       "dev": true
     },
     "memfs": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.10.tgz",
-      "integrity": "sha512-0bCUP+L79P4am30yP1msPzApwuMQG23TjwlwdHeEV5MxioDR1a0AgB0T9FfggU52eJuDCq8WVwb5ekznFyWiTQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.11.tgz",
+      "integrity": "sha512-GvsCITGAyDCxxsJ+X6prJexFQEhOCJaIlUbsAvjzSI5o5O7j2dle3jWvz5Z5aOdpOxW6ol3vI1+0ut+641F1+w==",
       "dev": true,
       "requires": {
         "fs-monkey": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^14.2.9"
+    "@angular/core": "^14.2.10"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^14.2.8",
+    "@angular-devkit/build-angular": "^14.2.9",
     "@angular-eslint/builder": "^14.1.2",
     "@angular-eslint/eslint-plugin": "^14.1.2",
     "@angular-eslint/eslint-plugin-template": "^14.1.2",
     "@angular-eslint/schematics": "^14.1.2",
     "@angular-eslint/template-parser": "^14.1.2",
-    "@angular/cli": "^14.2.8",
-    "@angular/common": "^14.2.9",
-    "@angular/compiler": "^14.2.9",
-    "@angular/compiler-cli": "^14.2.9",
-    "@angular/platform-browser": "^14.2.9",
-    "@angular/platform-browser-dynamic": "^14.2.9",
+    "@angular/cli": "^14.2.9",
+    "@angular/common": "^14.2.10",
+    "@angular/compiler": "^14.2.10",
+    "@angular/compiler-cli": "^14.2.10",
+    "@angular/platform-browser": "^14.2.10",
+    "@angular/platform-browser-dynamic": "^14.2.10",
     "@types/jasmine": "^4.3.0",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^18.11.9",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            14.2.8 -> 14.2.9         ng update @angular/cli
      @angular/core                           14.2.9 -> 14.2.10        ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>