### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "@angular-eslint/schematics": "^15.2.1",
         "@angular-eslint/template-parser": "^15.2.1",
         "@angular/cli": "^15.2.4",
-        "@angular/common": "^15.2.3",
-        "@angular/compiler": "^15.2.3",
-        "@angular/compiler-cli": "^15.2.3",
-        "@angular/platform-browser": "^15.2.3",
-        "@angular/platform-browser-dynamic": "^15.2.3",
+        "@angular/common": "^15.2.4",
+        "@angular/compiler": "^15.2.4",
+        "@angular/compiler-cli": "^15.2.4",
+        "@angular/platform-browser": "^15.2.4",
+        "@angular/platform-browser-dynamic": "^15.2.4",
         "@types/jasmine": "^4.3.1",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^18.15.6",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.0"
       },
       "peerDependencies": {
-        "@angular/core": "^15.2.3"
+        "@angular/core": "^15.2.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.3.tgz",
-      "integrity": "sha512-J68CSb57XadC2weHw7kmHjCdrHNgxPv8ZW6KlnmYvIRJrkKsZuCl+PvFe90VMDvHtlBnSnz8sjAPqoUxesMRNg==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.4.tgz",
+      "integrity": "sha512-RT6bo3RB768alor27i4KG9rTcsya58f2Pda/MjcNC5iR7WpmA4tE4h9x4JnI/1GCR3U1KAa4qrDrEFUJZoFofw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -613,14 +613,14 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "15.2.3",
+        "@angular/core": "15.2.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.3.tgz",
-      "integrity": "sha512-KdEb5vWptRON6lXhhu93DLog4ekfrlHD74bOWbGQ2F40mycXqLNigOxbDCYifIAeE0xmRxbyV9KBvS6LKLC9uA==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.4.tgz",
+      "integrity": "sha512-M4zqNCiSsNH2tc12yux9ZpGfSQ4vJ08iYxq6RJmS3CFJtDIw0SFc14ycHX+8rXYfLw92j0UTaDEAhjruAM51Zw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -629,7 +629,7 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "15.2.3"
+        "@angular/core": "15.2.4"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.3.tgz",
-      "integrity": "sha512-n52yntOPnVeQdNq612YyQ1KW27+BZq1YIxtkST6Xmrv6rFuduLVtBLMl+CpZ3vONBzMI1fY6svck6fPb0x4kbQ==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.4.tgz",
+      "integrity": "sha512-FCRNZ60PIKRt3rmjab7ca1E5Mc8Zt2izwD+VrzWeyBc51g5dVD+T/CRamJbmqRGw1hnn6BBM/VP9oDRcMVwGlg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.19.3",
@@ -663,7 +663,7 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "15.2.3",
+        "@angular/compiler": "15.2.4",
         "typescript": ">=4.8.2 <5.0"
       }
     },
@@ -707,9 +707,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.3.tgz",
-      "integrity": "sha512-e+d6upOqAyqE7MxxRthd1ZJILSKX+hXHCmujc48id8G3zhP0tD59iZ03KgUe8RMvXMlSBUhwOwDX39tr701eig==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.4.tgz",
+      "integrity": "sha512-ApWxICIOK47F/yh0Di/SFR3qMXZPpVLFainlIEauwpULKCLrYSJSnlF+zaDB6mMI1754skZZE69lX4uS2Byi+w==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.3.tgz",
-      "integrity": "sha512-73EdTiw9jR/l/t9MBKD5slWcIiaE3bHQY4oCKzywMYu6ANci+WkCu7Ek2SGGq69M4+bKRo1/e/5XF4vvmNOBYQ==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.4.tgz",
+      "integrity": "sha512-RVMqnVNy6kgtyZM7gRJF1nrsFBaGltySeyc4jvTIms7fpqxHvJFJ32r24h5QbgYbq18YwnWmcEkqZqg3nnyOaA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -734,9 +734,9 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "15.2.3",
-        "@angular/common": "15.2.3",
-        "@angular/core": "15.2.3"
+        "@angular/animations": "15.2.4",
+        "@angular/common": "15.2.4",
+        "@angular/core": "15.2.4"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.3.tgz",
-      "integrity": "sha512-HQ+xJzSa1O75s8Trcem8TnFu1rjbrzyRXfus/9Dpxam46ywIt1VuowSegz8K4hBaXnNFn53mZVpyK1hBtPq/bg==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.4.tgz",
+      "integrity": "sha512-WNEIjzrgmaouXVkIoUwe/kl8IjpZS5Ar2zDx9Twx/onngc/Nta0X5xLYTNNVM4u8pJSHObupeTMF4CY7ZLEQ+Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -756,10 +756,10 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "15.2.3",
-        "@angular/compiler": "15.2.3",
-        "@angular/core": "15.2.3",
-        "@angular/platform-browser": "15.2.3"
+        "@angular/common": "15.2.4",
+        "@angular/compiler": "15.2.4",
+        "@angular/core": "15.2.4",
+        "@angular/platform-browser": "15.2.4"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -16799,27 +16799,27 @@
       }
     },
     "@angular/common": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.3.tgz",
-      "integrity": "sha512-J68CSb57XadC2weHw7kmHjCdrHNgxPv8ZW6KlnmYvIRJrkKsZuCl+PvFe90VMDvHtlBnSnz8sjAPqoUxesMRNg==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.4.tgz",
+      "integrity": "sha512-RT6bo3RB768alor27i4KG9rTcsya58f2Pda/MjcNC5iR7WpmA4tE4h9x4JnI/1GCR3U1KAa4qrDrEFUJZoFofw==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.3.tgz",
-      "integrity": "sha512-KdEb5vWptRON6lXhhu93DLog4ekfrlHD74bOWbGQ2F40mycXqLNigOxbDCYifIAeE0xmRxbyV9KBvS6LKLC9uA==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.4.tgz",
+      "integrity": "sha512-M4zqNCiSsNH2tc12yux9ZpGfSQ4vJ08iYxq6RJmS3CFJtDIw0SFc14ycHX+8rXYfLw92j0UTaDEAhjruAM51Zw==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.3.tgz",
-      "integrity": "sha512-n52yntOPnVeQdNq612YyQ1KW27+BZq1YIxtkST6Xmrv6rFuduLVtBLMl+CpZ3vONBzMI1fY6svck6fPb0x4kbQ==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.4.tgz",
+      "integrity": "sha512-FCRNZ60PIKRt3rmjab7ca1E5Mc8Zt2izwD+VrzWeyBc51g5dVD+T/CRamJbmqRGw1hnn6BBM/VP9oDRcMVwGlg==",
       "dev": true,
       "requires": {
         "@babel/core": "7.19.3",
@@ -16868,27 +16868,27 @@
       }
     },
     "@angular/core": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.3.tgz",
-      "integrity": "sha512-e+d6upOqAyqE7MxxRthd1ZJILSKX+hXHCmujc48id8G3zhP0tD59iZ03KgUe8RMvXMlSBUhwOwDX39tr701eig==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.4.tgz",
+      "integrity": "sha512-ApWxICIOK47F/yh0Di/SFR3qMXZPpVLFainlIEauwpULKCLrYSJSnlF+zaDB6mMI1754skZZE69lX4uS2Byi+w==",
       "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.3.tgz",
-      "integrity": "sha512-73EdTiw9jR/l/t9MBKD5slWcIiaE3bHQY4oCKzywMYu6ANci+WkCu7Ek2SGGq69M4+bKRo1/e/5XF4vvmNOBYQ==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.4.tgz",
+      "integrity": "sha512-RVMqnVNy6kgtyZM7gRJF1nrsFBaGltySeyc4jvTIms7fpqxHvJFJ32r24h5QbgYbq18YwnWmcEkqZqg3nnyOaA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.3.tgz",
-      "integrity": "sha512-HQ+xJzSa1O75s8Trcem8TnFu1rjbrzyRXfus/9Dpxam46ywIt1VuowSegz8K4hBaXnNFn53mZVpyK1hBtPq/bg==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.4.tgz",
+      "integrity": "sha512-WNEIjzrgmaouXVkIoUwe/kl8IjpZS5Ar2zDx9Twx/onngc/Nta0X5xLYTNNVM4u8pJSHObupeTMF4CY7ZLEQ+Q==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^15.2.3"
+    "@angular/core": "^15.2.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.2.4",
@@ -37,11 +37,11 @@
     "@angular-eslint/schematics": "^15.2.1",
     "@angular-eslint/template-parser": "^15.2.1",
     "@angular/cli": "^15.2.4",
-    "@angular/common": "^15.2.3",
-    "@angular/compiler": "^15.2.3",
-    "@angular/compiler-cli": "^15.2.3",
-    "@angular/platform-browser": "^15.2.3",
-    "@angular/platform-browser-dynamic": "^15.2.3",
+    "@angular/common": "^15.2.4",
+    "@angular/compiler": "^15.2.4",
+    "@angular/compiler-cli": "^15.2.4",
+    "@angular/platform-browser": "^15.2.4",
+    "@angular/platform-browser-dynamic": "^15.2.4",
     "@types/jasmine": "^4.3.1",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^18.15.6",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/core                           15.2.3 -> 15.2.4         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>