### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "@angular-eslint/schematics": "^15.2.1",
         "@angular-eslint/template-parser": "^15.2.1",
         "@angular/cli": "^15.2.4",
-        "@angular/common": "^15.2.4",
-        "@angular/compiler": "^15.2.4",
-        "@angular/compiler-cli": "^15.2.4",
-        "@angular/platform-browser": "^15.2.4",
-        "@angular/platform-browser-dynamic": "^15.2.4",
+        "@angular/common": "^15.2.5",
+        "@angular/compiler": "^15.2.5",
+        "@angular/compiler-cli": "^15.2.5",
+        "@angular/platform-browser": "^15.2.5",
+        "@angular/platform-browser-dynamic": "^15.2.5",
         "@types/jasmine": "^4.3.1",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^18.15.11",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.0"
       },
       "peerDependencies": {
-        "@angular/core": "^15.2.4"
+        "@angular/core": "^15.2.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.4.tgz",
-      "integrity": "sha512-RT6bo3RB768alor27i4KG9rTcsya58f2Pda/MjcNC5iR7WpmA4tE4h9x4JnI/1GCR3U1KAa4qrDrEFUJZoFofw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.5.tgz",
+      "integrity": "sha512-6Wl1ak96NZvnL8p0eVsxHhaddv0/qYq2pQniKaKBfL9MVOQtAe07sPUDEZ6w0ApkmV63Giu4zFakaQMsmvxU0Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -613,14 +613,14 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "15.2.4",
+        "@angular/core": "15.2.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.4.tgz",
-      "integrity": "sha512-M4zqNCiSsNH2tc12yux9ZpGfSQ4vJ08iYxq6RJmS3CFJtDIw0SFc14ycHX+8rXYfLw92j0UTaDEAhjruAM51Zw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.5.tgz",
+      "integrity": "sha512-0mAFF6Ud4ojsb8qGLQCWYh/LgKKrnn1Fz788LzfYcLYhi7UZPiCFrQJrEcCXBKtQsk8sG335CA9Qk0I/qc35zg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -629,7 +629,7 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "15.2.4"
+        "@angular/core": "15.2.5"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.4.tgz",
-      "integrity": "sha512-FCRNZ60PIKRt3rmjab7ca1E5Mc8Zt2izwD+VrzWeyBc51g5dVD+T/CRamJbmqRGw1hnn6BBM/VP9oDRcMVwGlg==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.5.tgz",
+      "integrity": "sha512-NNrnvL0JMg6dZMuTgBTb/IVIFJwy2my5XTNLngTNBfDCVu0SL1TKrYnpqp2qRi2ip9XdNqCtNF7JFDEklVbK2A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.19.3",
@@ -663,7 +663,7 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "15.2.4",
+        "@angular/compiler": "15.2.5",
         "typescript": ">=4.8.2 <5.0"
       }
     },
@@ -707,9 +707,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.4.tgz",
-      "integrity": "sha512-ApWxICIOK47F/yh0Di/SFR3qMXZPpVLFainlIEauwpULKCLrYSJSnlF+zaDB6mMI1754skZZE69lX4uS2Byi+w==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.5.tgz",
+      "integrity": "sha512-GtmjJmwtzCuF4FDXIY+9UFMAcfPlJzJDBDF7mgEmD2YKf/HV5PSyU91lfv9yDPnAkdzlDAL9u4YxnGgoURY8/g==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.4.tgz",
-      "integrity": "sha512-RVMqnVNy6kgtyZM7gRJF1nrsFBaGltySeyc4jvTIms7fpqxHvJFJ32r24h5QbgYbq18YwnWmcEkqZqg3nnyOaA==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.5.tgz",
+      "integrity": "sha512-D19HL3UsvPX4s8yC4C4gphTNyQU75VuzcyGZ+6y1o1SQbVjF6UwSrztmb//4MCkpclb+avv669z5AEiTuBTnVQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -734,9 +734,9 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "15.2.4",
-        "@angular/common": "15.2.4",
-        "@angular/core": "15.2.4"
+        "@angular/animations": "15.2.5",
+        "@angular/common": "15.2.5",
+        "@angular/core": "15.2.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.4.tgz",
-      "integrity": "sha512-WNEIjzrgmaouXVkIoUwe/kl8IjpZS5Ar2zDx9Twx/onngc/Nta0X5xLYTNNVM4u8pJSHObupeTMF4CY7ZLEQ+Q==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.5.tgz",
+      "integrity": "sha512-NoGVeaR7K+RMcLpS2gI4hyMVeUqP057rw8Yfk15dHy3cM8icj5zVfyez3AADcO1XthNhE1sI1d+2LD4/GxwIKQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -756,10 +756,10 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "15.2.4",
-        "@angular/compiler": "15.2.4",
-        "@angular/core": "15.2.4",
-        "@angular/platform-browser": "15.2.4"
+        "@angular/common": "15.2.5",
+        "@angular/compiler": "15.2.5",
+        "@angular/core": "15.2.5",
+        "@angular/platform-browser": "15.2.5"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -16771,27 +16771,27 @@
       }
     },
     "@angular/common": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.4.tgz",
-      "integrity": "sha512-RT6bo3RB768alor27i4KG9rTcsya58f2Pda/MjcNC5iR7WpmA4tE4h9x4JnI/1GCR3U1KAa4qrDrEFUJZoFofw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.5.tgz",
+      "integrity": "sha512-6Wl1ak96NZvnL8p0eVsxHhaddv0/qYq2pQniKaKBfL9MVOQtAe07sPUDEZ6w0ApkmV63Giu4zFakaQMsmvxU0Q==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.4.tgz",
-      "integrity": "sha512-M4zqNCiSsNH2tc12yux9ZpGfSQ4vJ08iYxq6RJmS3CFJtDIw0SFc14ycHX+8rXYfLw92j0UTaDEAhjruAM51Zw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.5.tgz",
+      "integrity": "sha512-0mAFF6Ud4ojsb8qGLQCWYh/LgKKrnn1Fz788LzfYcLYhi7UZPiCFrQJrEcCXBKtQsk8sG335CA9Qk0I/qc35zg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.4.tgz",
-      "integrity": "sha512-FCRNZ60PIKRt3rmjab7ca1E5Mc8Zt2izwD+VrzWeyBc51g5dVD+T/CRamJbmqRGw1hnn6BBM/VP9oDRcMVwGlg==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.5.tgz",
+      "integrity": "sha512-NNrnvL0JMg6dZMuTgBTb/IVIFJwy2my5XTNLngTNBfDCVu0SL1TKrYnpqp2qRi2ip9XdNqCtNF7JFDEklVbK2A==",
       "dev": true,
       "requires": {
         "@babel/core": "7.19.3",
@@ -16840,27 +16840,27 @@
       }
     },
     "@angular/core": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.4.tgz",
-      "integrity": "sha512-ApWxICIOK47F/yh0Di/SFR3qMXZPpVLFainlIEauwpULKCLrYSJSnlF+zaDB6mMI1754skZZE69lX4uS2Byi+w==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.5.tgz",
+      "integrity": "sha512-GtmjJmwtzCuF4FDXIY+9UFMAcfPlJzJDBDF7mgEmD2YKf/HV5PSyU91lfv9yDPnAkdzlDAL9u4YxnGgoURY8/g==",
       "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.4.tgz",
-      "integrity": "sha512-RVMqnVNy6kgtyZM7gRJF1nrsFBaGltySeyc4jvTIms7fpqxHvJFJ32r24h5QbgYbq18YwnWmcEkqZqg3nnyOaA==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.5.tgz",
+      "integrity": "sha512-D19HL3UsvPX4s8yC4C4gphTNyQU75VuzcyGZ+6y1o1SQbVjF6UwSrztmb//4MCkpclb+avv669z5AEiTuBTnVQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.4.tgz",
-      "integrity": "sha512-WNEIjzrgmaouXVkIoUwe/kl8IjpZS5Ar2zDx9Twx/onngc/Nta0X5xLYTNNVM4u8pJSHObupeTMF4CY7ZLEQ+Q==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.5.tgz",
+      "integrity": "sha512-NoGVeaR7K+RMcLpS2gI4hyMVeUqP057rw8Yfk15dHy3cM8icj5zVfyez3AADcO1XthNhE1sI1d+2LD4/GxwIKQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^15.2.4"
+    "@angular/core": "^15.2.5"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.2.4",
@@ -37,11 +37,11 @@
     "@angular-eslint/schematics": "^15.2.1",
     "@angular-eslint/template-parser": "^15.2.1",
     "@angular/cli": "^15.2.4",
-    "@angular/common": "^15.2.4",
-    "@angular/compiler": "^15.2.4",
-    "@angular/compiler-cli": "^15.2.4",
-    "@angular/platform-browser": "^15.2.4",
-    "@angular/platform-browser-dynamic": "^15.2.4",
+    "@angular/common": "^15.2.5",
+    "@angular/compiler": "^15.2.5",
+    "@angular/compiler-cli": "^15.2.5",
+    "@angular/platform-browser": "^15.2.5",
+    "@angular/platform-browser-dynamic": "^15.2.5",
     "@types/jasmine": "^4.3.1",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^18.15.11",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/core                           15.2.4 -> 15.2.5         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>