### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "@angular-eslint/schematics": "^15.2.1",
         "@angular-eslint/template-parser": "^15.2.1",
         "@angular/cli": "^15.2.6",
-        "@angular/common": "^15.2.7",
-        "@angular/compiler": "^15.2.7",
-        "@angular/compiler-cli": "^15.2.7",
-        "@angular/platform-browser": "^15.2.7",
-        "@angular/platform-browser-dynamic": "^15.2.7",
+        "@angular/common": "^15.2.8",
+        "@angular/compiler": "^15.2.8",
+        "@angular/compiler-cli": "^15.2.8",
+        "@angular/platform-browser": "^15.2.8",
+        "@angular/platform-browser-dynamic": "^15.2.8",
         "@types/jasmine": "^4.3.1",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^18.15.13",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.0"
       },
       "peerDependencies": {
-        "@angular/core": "^15.2.7"
+        "@angular/core": "^15.2.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "15.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.7.tgz",
-      "integrity": "sha512-CbmrQeZ0yChQrF/ab3v+gv6x2uLbv/s1wZNUBSO/p1STz6BZzHRJqObVlfPlQvyBx5btBBy/+I1sUh1yumARDA==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.8.tgz",
+      "integrity": "sha512-yLDQihiRcVl38HrWMPbqgzOaSUw85AQH5BsGdjbS6BpoBQj3EXOpccCMFsuxOKxPG4toatgawNqrEnK0Jpv9Mw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -613,14 +613,14 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "15.2.7",
+        "@angular/core": "15.2.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "15.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.7.tgz",
-      "integrity": "sha512-SesyYI2ExUa13XukXgIsmfg3ar90HbWeWDJTgmzsIfph0M9t6+SaPGpf3FCtdBgNADIpUFp3cieCOJgLESzxYQ==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.8.tgz",
+      "integrity": "sha512-+dvspIDvuGoYqdL7r/3o9ojkR3fH1zevgC0ISJivcIrMi+WcJ0FV2JmJdnm8V52oNsHy+sMF9eEZGEbCbACE/A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -629,7 +629,7 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "15.2.7"
+        "@angular/core": "15.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "15.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.7.tgz",
-      "integrity": "sha512-4v51dOaT8GDUzRh6+mCLZOaYuU9FYX6vOHaLod9np3tVWPhcpoF2ZklRSiQDeFqrhr5B4vuCp/Lh9N2wzc22XQ==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.8.tgz",
+      "integrity": "sha512-fFxaDlbILo0t2t662qA0cjgn+kWItGlc1tFYKU6X7bvYb3t2e0cd9FzrFPLXUQVboGis83ULcJ2zkDxScnuPuQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.19.3",
@@ -663,7 +663,7 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "15.2.7",
+        "@angular/compiler": "15.2.8",
         "typescript": ">=4.8.2 <5.0"
       }
     },
@@ -707,9 +707,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "15.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.7.tgz",
-      "integrity": "sha512-iS7JCJubRFqdndoUdAnvNkQRT3tY5tNFupBQS/sytkwxVrdBg+Is5jpdgk741n824vTMsE+CnuY0SETar8rN6g==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.8.tgz",
+      "integrity": "sha512-NDs+g4uM4EhyCvluf8a0YBCFXsDAEfCMHOD5cS00Bl+liTQ7JwtmepkWXMyjLB92irC9JaR79kdy4BoIKOh8WA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "15.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.7.tgz",
-      "integrity": "sha512-aCbd7xyuP7c2eDITkOTDO2mqP550WHCBN8U6VnjysqtB5ocbJtR6z/MIRItN/Zx+xj3piiaKei//XIkb3Q5fXQ==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.8.tgz",
+      "integrity": "sha512-8sKFUld54inj0FnQ1ydhFxnDgsbbf43W9FALye/5uEtLgwwE/ZvkNYMaQ7hq1JPuQRMDj3gJkFqaLeFjplpHDA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -734,9 +734,9 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "15.2.7",
-        "@angular/common": "15.2.7",
-        "@angular/core": "15.2.7"
+        "@angular/animations": "15.2.8",
+        "@angular/common": "15.2.8",
+        "@angular/core": "15.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "15.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.7.tgz",
-      "integrity": "sha512-t1Nf7hgbcYvhmxuzgUtsV47jrI5CXUBqrtz5I0ilWG92zZTig5qvfd1/2Ub8NHz87uHNrnggyZpL2+4MJ26nyQ==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.8.tgz",
+      "integrity": "sha512-75HyoZNibA3u/FvdK4Aw5KMzUmS/nDk5N8s7gfM09fe1resSPgFiW8JJEkr1xiUdA2WtSRbHs34y5rHLDe7n1Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -756,10 +756,10 @@
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "15.2.7",
-        "@angular/compiler": "15.2.7",
-        "@angular/core": "15.2.7",
-        "@angular/platform-browser": "15.2.7"
+        "@angular/common": "15.2.8",
+        "@angular/compiler": "15.2.8",
+        "@angular/core": "15.2.8",
+        "@angular/platform-browser": "15.2.8"
       }
     },
     "node_modules/@assemblyscript/loader": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^15.2.7"
+    "@angular/core": "^15.2.8"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.2.6",
@@ -37,11 +37,11 @@
     "@angular-eslint/schematics": "^15.2.1",
     "@angular-eslint/template-parser": "^15.2.1",
     "@angular/cli": "^15.2.6",
-    "@angular/common": "^15.2.7",
-    "@angular/compiler": "^15.2.7",
-    "@angular/compiler-cli": "^15.2.7",
-    "@angular/platform-browser": "^15.2.7",
-    "@angular/platform-browser-dynamic": "^15.2.7",
+    "@angular/common": "^15.2.8",
+    "@angular/compiler": "^15.2.8",
+    "@angular/compiler-cli": "^15.2.8",
+    "@angular/platform-browser": "^15.2.8",
+    "@angular/platform-browser-dynamic": "^15.2.8",
     "@types/jasmine": "^4.3.1",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^18.15.13",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/core                           15.2.7 -> 15.2.8         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>