### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,17 @@
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^16.1.4",
-        "@angular-eslint/builder": "^16.0.3",
-        "@angular-eslint/eslint-plugin": "^16.0.3",
-        "@angular-eslint/eslint-plugin-template": "^16.0.3",
-        "@angular-eslint/schematics": "^16.0.3",
-        "@angular-eslint/template-parser": "^16.0.3",
+        "@angular-eslint/builder": "^16.1.0",
+        "@angular-eslint/eslint-plugin": "^16.1.0",
+        "@angular-eslint/eslint-plugin-template": "^16.1.0",
+        "@angular-eslint/schematics": "^16.1.0",
+        "@angular-eslint/template-parser": "^16.1.0",
         "@angular/cli": "^16.1.4",
-        "@angular/common": "^16.1.4",
-        "@angular/compiler": "^16.1.4",
-        "@angular/compiler-cli": "^16.1.4",
-        "@angular/platform-browser": "^16.1.4",
-        "@angular/platform-browser-dynamic": "^16.1.4",
+        "@angular/common": "^16.1.5",
+        "@angular/compiler": "^16.1.5",
+        "@angular/compiler-cli": "^16.1.5",
+        "@angular/platform-browser": "^16.1.5",
+        "@angular/platform-browser-dynamic": "^16.1.5",
         "@types/jasmine": "^4.3.5",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^20.4.2",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.1"
       },
       "peerDependencies": {
-        "@angular/core": "^16.1.4"
+        "@angular/core": "^16.1.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -274,13 +274,13 @@
       }
     },
     "node_modules/@angular-eslint/builder": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-16.0.3.tgz",
-      "integrity": "sha512-pv/CrnOHHOnBqhyBmqUPsIHKXOHYMJztxYJ83tjxeXL5Moyu5e6CBMIQ58UtqmgWfEIA3n7owYy9KvHTJcemyQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-16.1.0.tgz",
+      "integrity": "sha512-KIkE2SI1twFKoCiF/k2VR3ojOcc7TD1xPyY4kbUrx/Gxp+XEzar7O29I/ztzL4eHPBM+Uh3/NwS/jvjjBxjgAg==",
       "dev": true,
       "dependencies": {
-        "@nx/devkit": "16.2.2",
-        "nx": "16.2.2"
+        "@nx/devkit": "16.5.1",
+        "nx": "16.5.1"
       },
       "peerDependencies": {
         "eslint": "^7.20.0 || ^8.0.0",
@@ -288,19 +288,19 @@
       }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-16.0.3.tgz",
-      "integrity": "sha512-8zwY6ustiPXBEF3+jELKVwGk6j2HJn7GHbqAhDFR02YiE27iRMSGTHIAWGs6ZI7F1JgfrIsOHrUgzC1x95K6rg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-16.1.0.tgz",
+      "integrity": "sha512-5EFAWXuFJADr3imo/ZYshY8s0K7U7wyysnE2LXnpT9PAi5rmkzt70UNZNRuamCbXr4tdIiu+fXWOj7tUuJKnnw==",
       "dev": true
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-16.0.3.tgz",
-      "integrity": "sha512-1c+dFytcQDOA2wJ8/rtydMV6UYq1BgVfOcBXOr0WJxC9g8Cad9czcUOkW41WGrTp5kICMliV0ypH5eEaCM2WDQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-16.1.0.tgz",
+      "integrity": "sha512-BFzzJJlgQgWc8avdSBkaDWAzNSUqcwWy0L1iZSBdXGoIOxj72kLbwe99emb8M+rUfCveljQkeM2pcYu8XLbJIA==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/utils": "16.0.3",
-        "@typescript-eslint/utils": "5.59.7"
+        "@angular-eslint/utils": "16.1.0",
+        "@typescript-eslint/utils": "5.62.0"
       },
       "peerDependencies": {
         "eslint": "^7.20.0 || ^8.0.0",
@@ -308,16 +308,16 @@
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-16.0.3.tgz",
-      "integrity": "sha512-OKTMWOjC7F5tdv7gm2tlmgyr/uVyS1RWJZn4X/6D6p0kOpiDXmajtbYHD5tzbshX2Ep62Nt+rg8+1XGHrU0ScA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-16.1.0.tgz",
+      "integrity": "sha512-wQHWR5vqWGgO7mqoG5ixXeplIlz/OmxBJE9QMLPTZE8GdaTx8+F/5J37OWh84zCpD3mOa/FHYZxBDm2MfUmA1Q==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "16.0.3",
-        "@angular-eslint/utils": "16.0.3",
-        "@typescript-eslint/type-utils": "5.59.7",
-        "@typescript-eslint/utils": "5.59.7",
-        "aria-query": "5.1.3",
+        "@angular-eslint/bundled-angular-compiler": "16.1.0",
+        "@angular-eslint/utils": "16.1.0",
+        "@typescript-eslint/type-utils": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "aria-query": "5.3.0",
         "axobject-query": "3.1.1"
       },
       "peerDependencies": {
@@ -326,16 +326,16 @@
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-16.0.3.tgz",
-      "integrity": "sha512-vRdSY0ovE+wfTvYeguPp/QAxvGejLADO8CzJkas0PxdCQiyLuTscKsYE82XcvX2kitMexvH71lNF0ggnGoMRXA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-16.1.0.tgz",
+      "integrity": "sha512-L1tmP3R2krHyveaRXAvn/SeDoBFNpS1VtPPrzZm1NYr1qPcAxf3NtG2nnoyVFu6WZGt59ZGHNQ/dZxnXvm0UGg==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/eslint-plugin": "16.0.3",
-        "@angular-eslint/eslint-plugin-template": "16.0.3",
-        "@nx/devkit": "16.2.2",
+        "@angular-eslint/eslint-plugin": "16.1.0",
+        "@angular-eslint/eslint-plugin-template": "16.1.0",
+        "@nx/devkit": "16.5.1",
         "ignore": "5.2.4",
-        "nx": "16.2.2",
+        "nx": "16.5.1",
         "strip-json-comments": "3.1.1",
         "tmp": "0.2.1"
       },
@@ -355,12 +355,12 @@
       }
     },
     "node_modules/@angular-eslint/template-parser": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-16.0.3.tgz",
-      "integrity": "sha512-IAWdwp/S9QC3EMiVxSS0E3ABy9PSidN3PW0Ll2EtM3mzXMYlpZXmxqd+B1xV/xKWzhk1Mp04QX8hHfG6Vq+qaQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-16.1.0.tgz",
+      "integrity": "sha512-DOQtzVehtbO7+BQ+FMOXRsxGRjHb3ve6M+S4qASKTiI+twtONjRODcHezD3N4PDkjpKPbOnk7YnFsHur5csUNw==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "16.0.3",
+        "@angular-eslint/bundled-angular-compiler": "16.1.0",
         "eslint-scope": "^7.0.0"
       },
       "peerDependencies": {
@@ -391,13 +391,13 @@
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-16.0.3.tgz",
-      "integrity": "sha512-QsbUVHJLk+fE08/D4y3wOyGk1iX2LVSygw+uzilbaAXfjD5/c0Ei5FbVx2mMYPk+aOl4yrvGQW3dmetMiAR0MQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-16.1.0.tgz",
+      "integrity": "sha512-u5XscYUq1F/7RuwyVIV2a280QL27lyQz434VYR+Np/oO21NGj5jxoRKb55xhXT9EFVs5Sy4JYeEUp6S75J/cUw==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "16.0.3",
-        "@typescript-eslint/utils": "5.59.7"
+        "@angular-eslint/bundled-angular-compiler": "16.1.0",
+        "@typescript-eslint/utils": "5.62.0"
       },
       "peerDependencies": {
         "eslint": "^7.20.0 || ^8.0.0",
@@ -439,9 +439,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.1.4.tgz",
-      "integrity": "sha512-SDA8GZVY0nXCJaNUy13L22jAKuk1LZgQ6QzqOpqQc50C25bfBQbYv68PKjHCjQ62VxGKnDSTT85xCMNx+y/U4g==",
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.1.5.tgz",
+      "integrity": "sha512-XQVIpICniWXXMoXsr6X7Q3pVcYBeQ0FZF06BNNolkkkVuReYpqr3TwWrZfuB9TUmxdF6R5WZ+M3NAdXodDDUNA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -450,14 +450,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.1.4",
+        "@angular/core": "16.1.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.1.4.tgz",
-      "integrity": "sha512-5iKx8g+6/LtiRhbqMS2Jw1AshFUb4M8LO9WQKfRoE+5mZrDOYkAQYgOlAO7fk0mOCXeZcHJBbq2nuwDfwsZIiw==",
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.1.5.tgz",
+      "integrity": "sha512-QNyisdr9lEN43v/e/fjS0H1vrJBMY8lIGpxVY1OOERFjA1clfMhaz5fiPE3vWFV5TOm3/ym9z2xuRXM6UoyWoA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -466,7 +466,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.1.4"
+        "@angular/core": "16.1.5"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.1.4.tgz",
-      "integrity": "sha512-JerJOZeOLaHFHrfWMm4m9tEw+MdNNIMPj3TSauJ6uZPbFokGeqS2GsUBMjuQlwh5xY4duh1HtRsohvshpl306A==",
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.1.5.tgz",
+      "integrity": "sha512-j20hmPyM+rLJDU1y0ta9Uf7+o2oGjvGWGpyANbpuTlAfA1+VN5G3xD53FnNcmO6LZuAw0wDw6NDAyy+G55o8xQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.22.5",
@@ -498,14 +498,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.1.4",
+        "@angular/compiler": "16.1.5",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.1.4.tgz",
-      "integrity": "sha512-eWs++peAp+Lm2SHGfMsHAye2IOmlDKkVJ4dFf4TaZXW+AEev3FXKXLFp+dBUq8YkCKly7iAV26NXEUBOFFtplQ==",
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.1.5.tgz",
+      "integrity": "sha512-xmk+WeL3qtFb3BM2hsEq/kGHJinqaTNVJkK/m4TiGArY+hjJwfCOeuTss7nOkKXvhRkZxU9VP0tej1w3QV5Yzw==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.1.4.tgz",
-      "integrity": "sha512-eQ1dBh/6ZwJVeiNGrcW6ePFmWeS+Oheu1RpuZSsvM/fI6qfsZE+or9IJ61SFvsMs65SbrO90Akc+ZXmpEidPdA==",
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.1.5.tgz",
+      "integrity": "sha512-TLM29KPr0A0pQ0YEmSy0JUOkfBXfwfBFzXQSt9SOiUs0wgDVVLMdGOpR/tbvBx2QfrSU3qgOX8P1FXIPJch6TQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -530,9 +530,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.1.4",
-        "@angular/common": "16.1.4",
-        "@angular/core": "16.1.4"
+        "@angular/animations": "16.1.5",
+        "@angular/common": "16.1.5",
+        "@angular/core": "16.1.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -541,9 +541,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.1.4.tgz",
-      "integrity": "sha512-OIszPs3NLCZWL8BEvn458JotNMdXPGyEVToNa2cEVgtakVxkhrhmoFlwJTWJN4GRkHNL5h2Vb0JLEYICwr7sgg==",
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.1.5.tgz",
+      "integrity": "sha512-ugdIXeN5IVj9o15ywH32hxNI0ZLyakpBGqMTHZSeEhU/uN6ajAJX7z6okdMbJ7dlTyBO8eFV1KDX3aAz+sK9bg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -552,10 +552,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.1.4",
-        "@angular/compiler": "16.1.4",
-        "@angular/core": "16.1.4",
-        "@angular/platform-browser": "16.1.4"
+        "@angular/common": "16.1.5",
+        "@angular/compiler": "16.1.5",
+        "@angular/core": "16.1.5",
+        "@angular/platform-browser": "16.1.5"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3253,56 +3253,41 @@
       }
     },
     "node_modules/@nrwl/devkit": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.2.2.tgz",
-      "integrity": "sha512-R8OSh33HtGycSuu0KshpH/tsTdi6j4w7DuIb+Sa59UDIkchpvMeNAz8tj/05Z2tTntDZnYqPkmCs6rkZ4PvY4Q==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.5.1.tgz",
+      "integrity": "sha512-NB+DE/+AFJ7lKH/WBFyatJEhcZGj25F24ncDkwjZ6MzEiSOGOJS0LaV/R+VUsmS5EHTPXYOpn3zHWWAcJhyOmA==",
       "dev": true,
       "dependencies": {
-        "@nx/devkit": "16.2.2"
+        "@nx/devkit": "16.5.1"
       }
     },
     "node_modules/@nrwl/tao": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.2.2.tgz",
-      "integrity": "sha512-cPj6b+wSWs2WNFQ0p1fMyrvSLjkKJo7vXQTtd7MXNJT2NWEZdCtRy+nidZzjs7gKvVXGdZ8zDBXmCHWorOieXw==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.5.1.tgz",
+      "integrity": "sha512-x+gi/fKdM6uQNIti9exFlm3V5LBP3Y8vOEziO42HdOigyrXa0S0HD2WMpccmp6PclYKhwEDUjKJ39xh5sdh4Ig==",
       "dev": true,
       "dependencies": {
-        "nx": "16.2.2"
+        "nx": "16.5.1"
       },
       "bin": {
         "tao": "index.js"
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-16.2.2.tgz",
-      "integrity": "sha512-MTYzetk4AQ9u2syEb9z+drDsu6U6NRAXVuUDMNg0tpZcbtE9bCSLH2ngfvTCqmLrAMBsJZRdv0twS1iepMhlAg==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-16.5.1.tgz",
+      "integrity": "sha512-T1acZrVVmJw/sJ4PIGidCBYBiBqlg/jT9e8nIGXLSDS20xcLvfo4zBQf8UZLrmHglnwwpDpOWuVJCp2rYA5aDg==",
       "dev": true,
       "dependencies": {
-        "@nrwl/devkit": "16.2.2",
+        "@nrwl/devkit": "16.5.1",
         "ejs": "^3.1.7",
         "ignore": "^5.0.4",
-        "semver": "7.3.4",
+        "semver": "7.5.3",
         "tmp": "~0.2.1",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "nx": ">= 15 <= 17"
-      }
-    },
-    "node_modules/@nx/devkit/node_modules/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@nx/devkit/node_modules/tmp": {
@@ -3318,9 +3303,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.2.2.tgz",
-      "integrity": "sha512-CKfyLl92mhWqpv1hRTj3WgjVBY6yj3Et5T31m1N0assNWdTfuSB4ycdWzdlxXHx3yptnTOD/FCymTpUQI0GZRQ==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.5.1.tgz",
+      "integrity": "sha512-q98TFI4B/9N9PmKUr1jcbtD4yAFs1HfYd9jUXXTQOlfO9SbDjnrYJgZ4Fp9rMNfrBhgIQ4x1qx0AukZccKmH9Q==",
       "cpu": [
         "arm64"
       ],
@@ -3334,9 +3319,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.2.2.tgz",
-      "integrity": "sha512-++uDfp/Oo8DDVU53DiJVkRNjNbOLzahDH6dINeA/3yTCU/IS0wXoaoclNZBReMWlDKTVvWgLF/eSbGINMqUHRg==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.5.1.tgz",
+      "integrity": "sha512-j9HmL1l8k7EVJ3eOM5y8COF93gqrydpxCDoz23ZEtsY+JHY77VAiRQsmqBgEx9GGA2dXi9VEdS67B0+1vKariw==",
       "cpu": [
         "x64"
       ],
@@ -3349,10 +3334,26 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nx/nx-freebsd-x64": {
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.5.1.tgz",
+      "integrity": "sha512-CXSPT01aVS869tvCCF2tZ7LnCa8l41wJ3mTVtWBkjmRde68E5Up093hklRMyXb3kfiDYlfIKWGwrV4r0eH6x1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.2.2.tgz",
-      "integrity": "sha512-A4XFk63Q7fxgZaHnigIeofp/xOT2ZGDoNUyzld+UTlyJyNcClcOcqrro74aKOCG7PH0D56oE06JW3g7GKszgsA==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.5.1.tgz",
+      "integrity": "sha512-BhrumqJSZCWFfLFUKl4CAUwR0Y0G2H5EfFVGKivVecEQbb+INAek1aa6c89evg2/OvetQYsJ+51QknskwqvLsA==",
       "cpu": [
         "arm"
       ],
@@ -3366,9 +3367,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.2.2.tgz",
-      "integrity": "sha512-aQpTLVSawFVr33pBWjj8elqvjA5uWvzDW7hGaFQPgWgmjxrtJikIAkcLjfNOz8XYjRAP4OZkTVh4/E3GUch0kQ==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.5.1.tgz",
+      "integrity": "sha512-x7MsSG0W+X43WVv7JhiSq2eKvH2suNKdlUHEG09Yt0vm3z0bhtym1UCMUg3IUAK7jy9hhLeDaFVFkC6zo+H/XQ==",
       "cpu": [
         "arm64"
       ],
@@ -3382,9 +3383,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.2.2.tgz",
-      "integrity": "sha512-20vyNYQ2SYSaWdxORj9HdOyGxiqE8SauaFiBjjid6/e5mSyaSKu+HHGsvhDUqzlWn3OaABKBqx0iYa9Kmf3BOQ==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.5.1.tgz",
+      "integrity": "sha512-J+/v/mFjOm74I0PNtH5Ka+fDd+/dWbKhpcZ2R1/6b9agzZk+Ff/SrwJcSYFXXWKbPX+uQ4RcJoytT06Zs3s0ow==",
       "cpu": [
         "arm64"
       ],
@@ -3398,9 +3399,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.2.2.tgz",
-      "integrity": "sha512-0G8kYpEmGHD+tT7RvUEvVXvPbvQD9GfEjeWEzZAdNAAMJu7JFjIo/oZDJYV7cMvXnC+tbpI9Gba5xfv8Al95eA==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.5.1.tgz",
+      "integrity": "sha512-igooWJ5YxQ94Zft7IqgL+Lw0qHaY15Btw4gfK756g/YTYLZEt4tTvR1y6RnK/wdpE3sa68bFTLVBNCGTyiTiDQ==",
       "cpu": [
         "x64"
       ],
@@ -3414,9 +3415,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.2.2.tgz",
-      "integrity": "sha512-Incv7DbKLfh6kakzMBuy6GYRgI+jEdZBRiFw0GoN9EsknmrPT/URn+w6uuicGGEXOLYpO3HUO3E374+b5Wz2zg==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.5.1.tgz",
+      "integrity": "sha512-zF/exnPqFYbrLAduGhTmZ7zNEyADid2bzNQiIjJkh8Y6NpDwrQIwVIyvIxqynsjMrIs51kBH+8TUjKjj2Jgf5A==",
       "cpu": [
         "x64"
       ],
@@ -3430,9 +3431,9 @@
       }
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.2.2.tgz",
-      "integrity": "sha512-8m+Usj9faCl0pdQLFeBGhbYUObT3/tno5oGMPtJLyRjITNvTZAaIS4FFctp/rwJPehDBRQsUxwMJ2JRaU4jQdA==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.5.1.tgz",
+      "integrity": "sha512-qtqiLS9Y9TYyAbbpq58kRoOroko4ZXg5oWVqIWFHoxc5bGPweQSJCROEqd1AOl2ZDC6BxfuVHfhDDop1kK05WA==",
       "cpu": [
         "arm64"
       ],
@@ -3446,9 +3447,9 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.2.2.tgz",
-      "integrity": "sha512-liHtyVVOttcqHIV3Xrg/1AJzEgfiOCeqJsleHXHGgPr1fxPx7SIZaa3/QnDY1lNMN+t6Gvj0/r2Ba3iuptYD3Q==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.5.1.tgz",
+      "integrity": "sha512-kUJBLakK7iyA9WfsGGQBVennA4jwf5XIgm0lu35oMOphtZIluvzItMt0EYBmylEROpmpEIhHq0P6J9FA+WH0Rg==",
       "cpu": [
         "x64"
       ],
@@ -4366,13 +4367,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.7.tgz",
-      "integrity": "sha512-FL6hkYWK9zBGdxT2wWEd2W8ocXMu3K94i3gvMrjXpx+koFYdYV7KprKfirpgY34vTGzEPPuKoERpP8kD5h7vZQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.7",
-        "@typescript-eslint/visitor-keys": "5.59.7"
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4383,13 +4384,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.7.tgz",
-      "integrity": "sha512-ozuz/GILuYG7osdY5O5yg0QxXUAEoI4Go3Do5xeu+ERH9PorHBPSdvD3Tjp2NN2bNLh1NJQSsQu2TPu/Ly+HaQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.59.7",
-        "@typescript-eslint/utils": "5.59.7",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -4410,9 +4411,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.7.tgz",
-      "integrity": "sha512-UnVS2MRRg6p7xOSATscWkKjlf/NDKuqo5TdbWck6rIRZbmKpVNTLALzNvcjIfHBE7736kZOFc/4Z3VcZwuOM/A==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4423,13 +4424,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.7.tgz",
-      "integrity": "sha512-4A1NtZ1I3wMN2UGDkU9HMBL+TIQfbrh4uS0WDMMpf3xMRursDbqEf1ahh6vAAe3mObt8k3ZATnezwG4pdtWuUQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.7",
-        "@typescript-eslint/visitor-keys": "5.59.7",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4479,17 +4480,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.7.tgz",
-      "integrity": "sha512-yCX9WpdQKaLufz5luG4aJbOpdXf/fjwGMcLFXZVPUz3QqLirG5QcwwnIHNf8cjLjxK4qtzTO8udUtMQSAToQnQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.7",
-        "@typescript-eslint/types": "5.59.7",
-        "@typescript-eslint/typescript-estree": "5.59.7",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -4505,12 +4506,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.7.tgz",
-      "integrity": "sha512-tyN+X2jvMslUszIiYbF0ZleP+RqQsFVpGrKI6e0Eet1w8WmhsAtmzaqm8oM8WJQ1ysLwhnsK/4hYHJjOgJVfQQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.7",
+        "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -4698,9 +4699,9 @@
       "dev": true
     },
     "node_modules/@yarnpkg/parsers": {
-      "version": "3.0.0-rc.45",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.45.tgz",
-      "integrity": "sha512-Aj0aHBV/crFQTpKQvL6k1xNiOhnlfVLu06LunelQAvl1MTeWrSi8LD9UJJDCFJiG4kx8NysUE6Tx0KZyPQUzIw==",
+      "version": "3.0.0-rc.46",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.46.tgz",
+      "integrity": "sha512-aiATs7pSutzda/rq8fnuPwTglyVwjM22bNnK2ZgjrpAjQHSSl3lztd2f9evst1W/qnC58DRz7T7QndUDumAR4Q==",
       "dev": true,
       "dependencies": {
         "js-yaml": "^3.10.0",
@@ -5005,12 +5006,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "dependencies": {
-        "deep-equal": "^2.0.5"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-flatten": {
@@ -7065,6 +7066,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -12312,16 +12322,16 @@
       }
     },
     "node_modules/nx": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-16.2.2.tgz",
-      "integrity": "sha512-gOcpqs6wf8YdFIq6P0IlMxBGr2c27pM55zpqO7epSlN6NqW6SOFKnZa+6z4NV9qmifMqzWPx2VF0BY54ARuqYg==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-16.5.1.tgz",
+      "integrity": "sha512-I3hJRE4hG7JWAtncWwDEO3GVeGPpN0TtM8xH5ArZXyDuVeTth/i3TtJzdDzqXO1HHtIoAQN0xeq4n9cLuMil5g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@nrwl/tao": "16.2.2",
+        "@nrwl/tao": "16.5.1",
         "@parcel/watcher": "2.0.4",
         "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "^3.0.0-rc.18",
+        "@yarnpkg/parsers": "3.0.0-rc.46",
         "@zkochan/js-yaml": "0.0.6",
         "axios": "^1.0.0",
         "chalk": "^4.1.0",
@@ -12342,7 +12352,7 @@
         "minimatch": "3.0.5",
         "npm-run-path": "^4.0.1",
         "open": "^8.4.0",
-        "semver": "7.3.4",
+        "semver": "7.5.3",
         "string-width": "^4.2.3",
         "strong-log-transformer": "^2.1.0",
         "tar-stream": "~2.2.0",
@@ -12357,15 +12367,16 @@
         "nx": "bin/nx.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "16.2.2",
-        "@nx/nx-darwin-x64": "16.2.2",
-        "@nx/nx-linux-arm-gnueabihf": "16.2.2",
-        "@nx/nx-linux-arm64-gnu": "16.2.2",
-        "@nx/nx-linux-arm64-musl": "16.2.2",
-        "@nx/nx-linux-x64-gnu": "16.2.2",
-        "@nx/nx-linux-x64-musl": "16.2.2",
-        "@nx/nx-win32-arm64-msvc": "16.2.2",
-        "@nx/nx-win32-x64-msvc": "16.2.2"
+        "@nx/nx-darwin-arm64": "16.5.1",
+        "@nx/nx-darwin-x64": "16.5.1",
+        "@nx/nx-freebsd-x64": "16.5.1",
+        "@nx/nx-linux-arm-gnueabihf": "16.5.1",
+        "@nx/nx-linux-arm64-gnu": "16.5.1",
+        "@nx/nx-linux-arm64-musl": "16.5.1",
+        "@nx/nx-linux-x64-gnu": "16.5.1",
+        "@nx/nx-linux-x64-musl": "16.5.1",
+        "@nx/nx-win32-arm64-msvc": "16.5.1",
+        "@nx/nx-win32-x64-msvc": "16.5.1"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.4.2",
@@ -12510,21 +12521,6 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/nx/node_modules/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/nx/node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.1.4"
+    "@angular/core": "^16.1.5"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^16.1.4",
-    "@angular-eslint/builder": "^16.0.3",
-    "@angular-eslint/eslint-plugin": "^16.0.3",
-    "@angular-eslint/eslint-plugin-template": "^16.0.3",
-    "@angular-eslint/schematics": "^16.0.3",
-    "@angular-eslint/template-parser": "^16.0.3",
+    "@angular-eslint/builder": "^16.1.0",
+    "@angular-eslint/eslint-plugin": "^16.1.0",
+    "@angular-eslint/eslint-plugin-template": "^16.1.0",
+    "@angular-eslint/schematics": "^16.1.0",
+    "@angular-eslint/template-parser": "^16.1.0",
     "@angular/cli": "^16.1.4",
-    "@angular/common": "^16.1.4",
-    "@angular/compiler": "^16.1.4",
-    "@angular/compiler-cli": "^16.1.4",
-    "@angular/platform-browser": "^16.1.4",
-    "@angular/platform-browser-dynamic": "^16.1.4",
+    "@angular/common": "^16.1.5",
+    "@angular/compiler": "^16.1.5",
+    "@angular/compiler-cli": "^16.1.5",
+    "@angular/platform-browser": "^16.1.5",
+    "@angular/platform-browser-dynamic": "^16.1.5",
     "@types/jasmine": "^4.3.5",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^20.4.2",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular-eslint/schematics              16.0.3 -> 16.1.0         ng update @angular-eslint/schematics
      @angular/core                           16.1.4 -> 16.1.5         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>