### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^16.1.6",
+        "@angular-devkit/build-angular": "^16.1.8",
         "@angular-eslint/builder": "^16.1.0",
         "@angular-eslint/eslint-plugin": "^16.1.0",
         "@angular-eslint/eslint-plugin-template": "^16.1.0",
         "@angular-eslint/schematics": "^16.1.0",
         "@angular-eslint/template-parser": "^16.1.0",
-        "@angular/cli": "^16.1.6",
-        "@angular/common": "^16.1.7",
-        "@angular/compiler": "^16.1.7",
-        "@angular/compiler-cli": "^16.1.7",
-        "@angular/platform-browser": "^16.1.7",
-        "@angular/platform-browser-dynamic": "^16.1.7",
+        "@angular/cli": "^16.1.8",
+        "@angular/common": "^16.1.8",
+        "@angular/compiler": "^16.1.8",
+        "@angular/compiler-cli": "^16.1.8",
+        "@angular/platform-browser": "^16.1.8",
+        "@angular/platform-browser-dynamic": "^16.1.8",
         "@types/jasmine": "^4.3.5",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^20.4.7",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.1"
       },
       "peerDependencies": {
-        "@angular/core": "^16.1.7"
+        "@angular/core": "^16.1.8"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1601.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1601.6.tgz",
-      "integrity": "sha512-dY+/FNUNrOj+m4iG5/v8N0PfbDmjkjjoy/YkquRHS1yo7fGGDFNqji2552mbtjN6/LwyWDhOO7fxdqppadjnvA==",
+      "version": "0.1601.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1601.8.tgz",
+      "integrity": "sha512-kOXVGwsQnZvtz2UZNefcEy64Jiwq0eSoQUeozvDXOaYRJABLjPKI2YaarvKC9/Z1SGLuje0o/eRJO4T8aRk9rQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.1.6",
+        "@angular-devkit/core": "16.1.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.1.6.tgz",
-      "integrity": "sha512-IEC1tApX8/Qa/RIVmbj0nYbOQ5WGcrkGNJ7D42q4DkIo74XKPzxDRruJE1RCjdZsj8lf4CCCZgSOPBsEI8Zbdw==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.1.8.tgz",
+      "integrity": "sha512-iyElPBQdcJq2plw5YqSz4mzNUfSRXI3ISFTEwPtimzPOorsj/OxB3Z6kJ8fDUsBAJ5OKR7xL7VnQJJ3S+05RhQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1601.6",
-        "@angular-devkit/build-webpack": "0.1601.6",
-        "@angular-devkit/core": "16.1.6",
+        "@angular-devkit/architect": "0.1601.8",
+        "@angular-devkit/build-webpack": "0.1601.8",
+        "@angular-devkit/core": "16.1.8",
         "@babel/core": "7.22.5",
         "@babel/generator": "7.22.7",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -109,7 +109,7 @@
         "@babel/runtime": "7.22.5",
         "@babel/template": "7.22.5",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "16.1.6",
+        "@ngtools/webpack": "16.1.8",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.14",
@@ -119,7 +119,7 @@
         "cacache": "17.1.3",
         "chokidar": "3.5.3",
         "copy-webpack-plugin": "11.0.0",
-        "critters": "0.0.19",
+        "critters": "0.0.20",
         "css-loader": "6.8.1",
         "esbuild-wasm": "0.17.19",
         "fast-glob": "3.2.12",
@@ -211,12 +211,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1601.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1601.6.tgz",
-      "integrity": "sha512-Uz/GjnhgAqSDPxrO4HP/tHNGPPZU3tEShtAVKyAypBl20bh2Aw1L5D+lCZi/Uq3Sh2JTPD9/M0ei2u9CMLhLDw==",
+      "version": "0.1601.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1601.8.tgz",
+      "integrity": "sha512-LUMA3xNnN4IY/FPaqyF6rzba+QVxl3vA+v0l71CBIKNU+Qee6D9xe8KG0Bn7relqDhWZOSHY0nhhO2mBoz4iQg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1601.6",
+        "@angular-devkit/architect": "0.1601.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.1.6.tgz",
-      "integrity": "sha512-3OjtrPWvsqVkMBwqPeE65ccCIw56FooNpVVAJ0XwhVQv5mA81pmbCzU7JsR6U449ZT7O4cQblzZMQvWvx74HCg==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.1.8.tgz",
+      "integrity": "sha512-dSRD/+bGanArIXkj+kaU1kDFleZeQMzmBiOXX+pK0Ah9/0Yn1VmY3RZh1zcX9vgIQXV+t7UPrTpOjaERMUtVGw==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -256,12 +256,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.1.6.tgz",
-      "integrity": "sha512-KA8P78gaS76HMHGBOM8JHJXWLOxCIShYVB2Un/Cu6z3jVODvXq+ILZUc1Y0RsAce/vsl2wf8qpoh5Lku9KJHUQ==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.1.8.tgz",
+      "integrity": "sha512-6LyzMdFJs337RTxxkI2U1Ndw0CW5mMX/aXWl8d7cW2odiSrAg8IdlMqpc+AM8+CPfsB0FtS1aWkEZqJLT0jHOg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.1.6",
+        "@angular-devkit/core": "16.1.8",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.0",
         "ora": "5.4.1",
@@ -405,15 +405,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.1.6.tgz",
-      "integrity": "sha512-yXVgUKMXxlAHkhc6xk3ljR7TXpMLBykyu8do+ooSP08VKEQnWjTdVgrcOHd0n5w9YHXUQgBSmjDKxtQaBmvyZQ==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.1.8.tgz",
+      "integrity": "sha512-amOIHMq8EvixhnI+do5Bcy6IZSFAJx0njhhLM4ltDuNUczH8VH0hNegZKxhb8K87AMO8jITFM+NLrzccyghsDQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1601.6",
-        "@angular-devkit/core": "16.1.6",
-        "@angular-devkit/schematics": "16.1.6",
-        "@schematics/angular": "16.1.6",
+        "@angular-devkit/architect": "0.1601.8",
+        "@angular-devkit/core": "16.1.8",
+        "@angular-devkit/schematics": "16.1.8",
+        "@schematics/angular": "16.1.8",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -439,9 +439,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.1.7.tgz",
-      "integrity": "sha512-7WwYwtJjuJtUkutB+aMCvtV5zxa43T4x+kqT+kS4KnUmLv5KdrGPxcS+/7YUuKEELWp1SG032UTwGPX0DXxH4g==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.1.8.tgz",
+      "integrity": "sha512-Zm+Ysxdf74VwG3mbAqs2v1QFUR+h9RyJBXF5VFABEpgFw7NUOBKrayjJmKjgZ0TBAmL2+nXehJgcPph3zNp3sg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -450,14 +450,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.1.7",
+        "@angular/core": "16.1.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.1.7.tgz",
-      "integrity": "sha512-93nbMFPSpKNfUyuRvEQxPdYLU6g25oZ4Gp7ewzNLyDHIbTQv6FwsthHfgPigPJJUUyKak6Gr3koFsgk7Dl3LAA==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.1.8.tgz",
+      "integrity": "sha512-jF2zk3LjrcI/xpjJG6yoLiL2t2l5227i8SjhRUawAL1sy0xtb/PiSLjCNhuSgyixbB/8az/YezZe11MSg48FDg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -466,7 +466,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.1.7"
+        "@angular/core": "16.1.8"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.1.7.tgz",
-      "integrity": "sha512-6iuogfVrbCh6o4hWbNCClsLQdLtlXiaNc72LGz5LMXI0TOwKVlRXhbzhiQeLS0/nsYIdHFbgyr1aepI2wQA3mQ==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.1.8.tgz",
+      "integrity": "sha512-Whk3RBnEYwN0c6Mo7hU6JDpHSyKONmIQEN8ViHJXwmyHK8w+/Z27iBw10QiyWUMtYb4tIM1xSLhRFAwH/3WnPQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.22.5",
@@ -498,14 +498,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.1.7",
+        "@angular/compiler": "16.1.8",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.1.7.tgz",
-      "integrity": "sha512-Wl5BR9X1xnV7Z9v/MNVANhymuTKAuRv4etr4rRgaC5NbbJSuFM4y+mg4yVI4wmrYJo0gKRcV9+2mHaePr41fTg==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.1.8.tgz",
+      "integrity": "sha512-XtOpY9HA85hPGrPwe1rgE8NJ3bFWbuJFx4SUlzB66k9B5jo8bD2Dxl/0id55RFS5gmvCe/Qhh0zoGyMpkWjMHA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.1.7.tgz",
-      "integrity": "sha512-AjdUUv5+v50cclHPsKVVdNRdCQZJMGNKmvxyLgeGj2hs61lGoJxBYcYqPre2PpM0SvezNJBreUvjwqM3ttOjng==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.1.8.tgz",
+      "integrity": "sha512-wfUCVU7DLMHy5Rw7LY8KSTuLk0ff2bWElT6WSAKXXFEPjQiWuXbbIe+gglJX5HFQQHoyVwNbsSDIIgEp535Kvw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -530,9 +530,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.1.7",
-        "@angular/common": "16.1.7",
-        "@angular/core": "16.1.7"
+        "@angular/animations": "16.1.8",
+        "@angular/common": "16.1.8",
+        "@angular/core": "16.1.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -541,9 +541,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.1.7.tgz",
-      "integrity": "sha512-xoT4wDl7Kurg2N5gcLNmkvqYx14xnYwa2Zm1ZIOM7kYMRXiAg1+XBzaxFXog0fCCs/lqUKUwaNn32YpLKwMNaw==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.1.8.tgz",
+      "integrity": "sha512-mhQH78Zn/oFe+U8DmVvPJ0/7neDlnKcgktQ7f1vFNibRLqkmHW/o1vZ0B7CAmO+yzGbB8mt+RBCFAfA7g3oRDg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -552,10 +552,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.1.7",
-        "@angular/compiler": "16.1.7",
-        "@angular/core": "16.1.7",
-        "@angular/platform-browser": "16.1.7"
+        "@angular/common": "16.1.8",
+        "@angular/compiler": "16.1.8",
+        "@angular/core": "16.1.8",
+        "@angular/platform-browser": "16.1.8"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3067,9 +3067,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.1.6.tgz",
-      "integrity": "sha512-rDE1bV3+Ys/VyeD6l7JKtbs3+bTQAfWhi7meEuq5mkaJHOERu6Z40ce866faAIX2I1AVpsSv8rLlb7kB7t7kzw==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.1.8.tgz",
+      "integrity": "sha512-co2SC1a822655Ek2f6fkMFsswHeCm2obNceb0kftLSpqomCgPAC3T447pB3TE1Iw+BEMFdjrAgIrp3nyYWwHsQ==",
       "dev": true,
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -3620,13 +3620,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.1.6.tgz",
-      "integrity": "sha512-BxghkeLfnMgV0D4DZDcbfPpox/Orw1ismSVGoQMIV/Daj2pqfSK+n97NAu0r0EsQyR5agPxOX9khVft+otODhg==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.1.8.tgz",
+      "integrity": "sha512-gTHy1A/E9BCr0sj3VCr6eBYkgVkO96QWiZcFumedGnvstvp5wiCoIoJPLLfYaxVt1vt08xmnmS3OZ3r0qCLdpA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.1.6",
-        "@angular-devkit/schematics": "16.1.6",
+        "@angular-devkit/core": "16.1.8",
+        "@angular-devkit/schematics": "16.1.8",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -6596,9 +6596,9 @@
       }
     },
     "node_modules/critters": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.19.tgz",
-      "integrity": "sha512-Fm4ZAXsG0VzWy1U30rP4qxbaWGSsqXDgSupJW1OUJGDAs0KWC+j37v7p5a2kZ9BPJvhRzWm3be+Hc9WvQOBUOw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.20.tgz",
+      "integrity": "sha512-CImNRorKOl5d8TWcnAz5n5izQ6HFsvz29k327/ELy6UFcmbiZNOsinaKvzv16WZR0P6etfSWYzE47C4/56B3Uw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.1.7"
+    "@angular/core": "^16.1.8"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.1.6",
+    "@angular-devkit/build-angular": "^16.1.8",
     "@angular-eslint/builder": "^16.1.0",
     "@angular-eslint/eslint-plugin": "^16.1.0",
     "@angular-eslint/eslint-plugin-template": "^16.1.0",
     "@angular-eslint/schematics": "^16.1.0",
     "@angular-eslint/template-parser": "^16.1.0",
-    "@angular/cli": "^16.1.6",
-    "@angular/common": "^16.1.7",
-    "@angular/compiler": "^16.1.7",
-    "@angular/compiler-cli": "^16.1.7",
-    "@angular/platform-browser": "^16.1.7",
-    "@angular/platform-browser-dynamic": "^16.1.7",
+    "@angular/cli": "^16.1.8",
+    "@angular/common": "^16.1.8",
+    "@angular/compiler": "^16.1.8",
+    "@angular/compiler-cli": "^16.1.8",
+    "@angular/platform-browser": "^16.1.8",
+    "@angular/platform-browser-dynamic": "^16.1.8",
     "@types/jasmine": "^4.3.5",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^20.4.7",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            16.1.6 -> 16.1.8         ng update @angular/cli
      @angular/core                           16.1.7 -> 16.1.8         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>