### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,17 @@
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^16.2.0",
-        "@angular-eslint/builder": "^16.1.0",
-        "@angular-eslint/eslint-plugin": "^16.1.0",
-        "@angular-eslint/eslint-plugin-template": "^16.1.0",
-        "@angular-eslint/schematics": "^16.1.0",
-        "@angular-eslint/template-parser": "^16.1.0",
+        "@angular-eslint/builder": "^16.1.1",
+        "@angular-eslint/eslint-plugin": "^16.1.1",
+        "@angular-eslint/eslint-plugin-template": "^16.1.1",
+        "@angular-eslint/schematics": "^16.1.1",
+        "@angular-eslint/template-parser": "^16.1.1",
         "@angular/cli": "^16.2.0",
-        "@angular/common": "^16.2.0",
-        "@angular/compiler": "^16.2.0",
-        "@angular/compiler-cli": "^16.2.0",
-        "@angular/platform-browser": "^16.2.0",
-        "@angular/platform-browser-dynamic": "^16.2.0",
+        "@angular/common": "^16.2.1",
+        "@angular/compiler": "^16.2.1",
+        "@angular/compiler-cli": "^16.2.1",
+        "@angular/platform-browser": "^16.2.1",
+        "@angular/platform-browser-dynamic": "^16.2.1",
         "@types/jasmine": "^4.3.5",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^20.5.0",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.1"
       },
       "peerDependencies": {
-        "@angular/core": "^16.2.0"
+        "@angular/core": "^16.2.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -718,9 +718,9 @@
       }
     },
     "node_modules/@angular-eslint/builder": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-16.1.0.tgz",
-      "integrity": "sha512-KIkE2SI1twFKoCiF/k2VR3ojOcc7TD1xPyY4kbUrx/Gxp+XEzar7O29I/ztzL4eHPBM+Uh3/NwS/jvjjBxjgAg==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-16.1.1.tgz",
+      "integrity": "sha512-NaB/A0mmlzp7laiucRUsRyoCrOE1In3UifsGP0vD6yjUpefk4g0v+0vCg8mhsIky8gYDtBE9YRfUiLA9FlF/FA==",
       "dev": true,
       "dependencies": {
         "@nx/devkit": "16.5.1",
@@ -732,18 +732,18 @@
       }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-16.1.0.tgz",
-      "integrity": "sha512-5EFAWXuFJADr3imo/ZYshY8s0K7U7wyysnE2LXnpT9PAi5rmkzt70UNZNRuamCbXr4tdIiu+fXWOj7tUuJKnnw==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-16.1.1.tgz",
+      "integrity": "sha512-TB01AWZBDfrZBxN1I50HfBXtC7q4NI5fwl1aS4tOfef2/kQjTtR9zmha8CsxjDkAOa9tA/4MUayAMqEBQLuHKQ==",
       "dev": true
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-16.1.0.tgz",
-      "integrity": "sha512-BFzzJJlgQgWc8avdSBkaDWAzNSUqcwWy0L1iZSBdXGoIOxj72kLbwe99emb8M+rUfCveljQkeM2pcYu8XLbJIA==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-16.1.1.tgz",
+      "integrity": "sha512-GauEwFGEcgIdsld4cVarFJYYxaRbMLzbpxyvBUDFg4LNjlcQNt7zfqXRLJoZAaFJFPtGtAoo1+6BlEKErsntuQ==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/utils": "16.1.0",
+        "@angular-eslint/utils": "16.1.1",
         "@typescript-eslint/utils": "5.62.0"
       },
       "peerDependencies": {
@@ -752,13 +752,13 @@
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-16.1.0.tgz",
-      "integrity": "sha512-wQHWR5vqWGgO7mqoG5ixXeplIlz/OmxBJE9QMLPTZE8GdaTx8+F/5J37OWh84zCpD3mOa/FHYZxBDm2MfUmA1Q==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-16.1.1.tgz",
+      "integrity": "sha512-hwbpiUxLIY3TnZycieh+G4fbTWGMfzKx076O5Vuh2H4ZfXfs6ZXoi3Z0TH6X9lTmdgrwzOg1v4o5kdqu7MqPBg==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "16.1.0",
-        "@angular-eslint/utils": "16.1.0",
+        "@angular-eslint/bundled-angular-compiler": "16.1.1",
+        "@angular-eslint/utils": "16.1.1",
         "@typescript-eslint/type-utils": "5.62.0",
         "@typescript-eslint/utils": "5.62.0",
         "aria-query": "5.3.0",
@@ -770,13 +770,13 @@
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-16.1.0.tgz",
-      "integrity": "sha512-L1tmP3R2krHyveaRXAvn/SeDoBFNpS1VtPPrzZm1NYr1qPcAxf3NtG2nnoyVFu6WZGt59ZGHNQ/dZxnXvm0UGg==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-16.1.1.tgz",
+      "integrity": "sha512-KlR01gpURPjz5OcoEvmKv3zi8l6lFpXYmqkXbGMCz828QlqBz1X7iGLAPJki+WUFSFKbRsf4qqaWq6O/8vph7Q==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/eslint-plugin": "16.1.0",
-        "@angular-eslint/eslint-plugin-template": "16.1.0",
+        "@angular-eslint/eslint-plugin": "16.1.1",
+        "@angular-eslint/eslint-plugin-template": "16.1.1",
         "@nx/devkit": "16.5.1",
         "ignore": "5.2.4",
         "nx": "16.5.1",
@@ -799,12 +799,12 @@
       }
     },
     "node_modules/@angular-eslint/template-parser": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-16.1.0.tgz",
-      "integrity": "sha512-DOQtzVehtbO7+BQ+FMOXRsxGRjHb3ve6M+S4qASKTiI+twtONjRODcHezD3N4PDkjpKPbOnk7YnFsHur5csUNw==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-16.1.1.tgz",
+      "integrity": "sha512-ZJ+M4+JGYcsIP/t+XiuzL5A5pCjjCen272U3/M/WqIMDDxyIKrHubK1bVtr2kndCEudqud+WyJU0ub13UIwGgw==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "16.1.0",
+        "@angular-eslint/bundled-angular-compiler": "16.1.1",
         "eslint-scope": "^7.0.0"
       },
       "peerDependencies": {
@@ -835,12 +835,12 @@
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-16.1.0.tgz",
-      "integrity": "sha512-u5XscYUq1F/7RuwyVIV2a280QL27lyQz434VYR+Np/oO21NGj5jxoRKb55xhXT9EFVs5Sy4JYeEUp6S75J/cUw==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-16.1.1.tgz",
+      "integrity": "sha512-cmSTyFFY2TMLjhKdju0KQ9GB6nnXt1AbY9tZ0UtWGo3NKbrBUogc+PR9ma17VRAGhvdj/sSVkStphJH3F7rUgQ==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "16.1.0",
+        "@angular-eslint/bundled-angular-compiler": "16.1.1",
         "@typescript-eslint/utils": "5.62.0"
       },
       "peerDependencies": {
@@ -898,9 +898,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.0.tgz",
-      "integrity": "sha512-ByrDLsTBarzqRmq4GS841Ku0lvB4L2wfOCfGEIw2ZuiNbZlDA5O/qohQgJnHR5d9meVJnu9NgdbeyMzk90xZNg==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.1.tgz",
+      "integrity": "sha512-druackA5JQpvfS8cD8DFtPRXGRKbhx3mQ778t1n6x3fXpIdGaAX+nSAgAKhIoF7fxWmu0KuHGzb+3BFlZRyTXw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -909,14 +909,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.0",
+        "@angular/core": "16.2.1",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.0.tgz",
-      "integrity": "sha512-Ai0CKRUDlMY6iFCeoRsC+soVFTU7eyMDmNzeakdmNvGYMdLdjH8WvgaNukesi6WX7YBIQIKTPJVral8fXBQroQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.1.tgz",
+      "integrity": "sha512-dPauu+ESn79d66U9nBvnunNuBk/UMqnm7iL9Q31J8OKYN/4vrKbsO57pmULOft/GRAYsE3FdLBH0NkocFZKIMQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -925,7 +925,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.0"
+        "@angular/core": "16.2.1"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.0.tgz",
-      "integrity": "sha512-IGRpEJwbzOLFsLj2qgTHpZ6nNcRjKDYaaAnVx+B1CfK4DP31PIsZLgsWcEcYt7KbF/FUlrCNwdBxrqE7rDxZaw==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.1.tgz",
+      "integrity": "sha512-A5SyNZTZnXSCL5JVXHKbYj9p2dRYoeFnb6hGQFt2AuCcpUjVIIdwHtre3YzkKe5sFwepPctdoRe2fRXlTfTRjA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.22.5",
@@ -957,14 +957,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.2.0",
+        "@angular/compiler": "16.2.1",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.0.tgz",
-      "integrity": "sha512-iwUWFw+JmRxw0chcNoqhXVR8XUTE+Rszhy22iSCkK0Jo8IJqEad1d2dQoFu1QfqOVdPMZtpJDmC/ppQ/f5c5aA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.1.tgz",
+      "integrity": "sha512-Y+0jssQnJPovxMv9cDKYlp6BBHeFBLOHd/+FPv5IIGD1c7NwBP/TImJxCaIV78a57xnO8L0SFacDg/kULzvKrg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -978,9 +978,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.0.tgz",
-      "integrity": "sha512-6xjZFnSD0C8ylDbzKpsxCJ4pLJDRvippr9Wj9RCeDQvAzMibsqIjpbesyOccw3hO+jheJQRhM/rZeO1ubZU94w==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.1.tgz",
+      "integrity": "sha512-SH8zRiRAcw0B5/tVlEc5U/lN5F8g+JizSuu7BQvpCAQEDkM6IjF9LP36Bjav7JuadItbWLfT6peWYa1sJvax2w==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -989,9 +989,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.2.0",
-        "@angular/common": "16.2.0",
-        "@angular/core": "16.2.0"
+        "@angular/animations": "16.2.1",
+        "@angular/common": "16.2.1",
+        "@angular/core": "16.2.1"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.0.tgz",
-      "integrity": "sha512-kLxgR+ichWb6dNA1JUAh0JB+iSrObkomd10porGQWVxAGmHqg1eiB3bBaSAgcaLftsrmEguIH8O9AEfq+HLfrA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.1.tgz",
+      "integrity": "sha512-dKMCSrbD/joOMXM1mhDOKNDZ1BxwO9r9uu5ZxY0L/fWm/ousgMucNikLr38vBudgWM8CN6BuabzkxWKcqi3k4g==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1011,10 +1011,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.2.0",
-        "@angular/compiler": "16.2.0",
-        "@angular/core": "16.2.0",
-        "@angular/platform-browser": "16.2.0"
+        "@angular/common": "16.2.1",
+        "@angular/compiler": "16.2.1",
+        "@angular/core": "16.2.1",
+        "@angular/platform-browser": "16.2.1"
       }
     },
     "node_modules/@assemblyscript/loader": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.2.0"
+    "@angular/core": "^16.2.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^16.2.0",
-    "@angular-eslint/builder": "^16.1.0",
-    "@angular-eslint/eslint-plugin": "^16.1.0",
-    "@angular-eslint/eslint-plugin-template": "^16.1.0",
-    "@angular-eslint/schematics": "^16.1.0",
-    "@angular-eslint/template-parser": "^16.1.0",
+    "@angular-eslint/builder": "^16.1.1",
+    "@angular-eslint/eslint-plugin": "^16.1.1",
+    "@angular-eslint/eslint-plugin-template": "^16.1.1",
+    "@angular-eslint/schematics": "^16.1.1",
+    "@angular-eslint/template-parser": "^16.1.1",
     "@angular/cli": "^16.2.0",
-    "@angular/common": "^16.2.0",
-    "@angular/compiler": "^16.2.0",
-    "@angular/compiler-cli": "^16.2.0",
-    "@angular/platform-browser": "^16.2.0",
-    "@angular/platform-browser-dynamic": "^16.2.0",
+    "@angular/common": "^16.2.1",
+    "@angular/compiler": "^16.2.1",
+    "@angular/compiler-cli": "^16.2.1",
+    "@angular/platform-browser": "^16.2.1",
+    "@angular/platform-browser-dynamic": "^16.2.1",
     "@types/jasmine": "^4.3.5",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^20.5.0",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular-eslint/schematics              16.1.0 -> 16.1.1         ng update @angular-eslint/schematics
      @angular/core                           16.2.0 -> 16.2.1         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>