### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "@angular-eslint/schematics": "^16.1.1",
         "@angular-eslint/template-parser": "^16.1.1",
         "@angular/cli": "^16.2.0",
-        "@angular/common": "^16.2.1",
-        "@angular/compiler": "^16.2.1",
-        "@angular/compiler-cli": "^16.2.1",
-        "@angular/platform-browser": "^16.2.1",
-        "@angular/platform-browser-dynamic": "^16.2.1",
+        "@angular/common": "^16.2.2",
+        "@angular/compiler": "^16.2.2",
+        "@angular/compiler-cli": "^16.2.2",
+        "@angular/platform-browser": "^16.2.2",
+        "@angular/platform-browser-dynamic": "^16.2.2",
         "@types/jasmine": "^4.3.5",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^20.5.6",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.1"
       },
       "peerDependencies": {
-        "@angular/core": "^16.2.1"
+        "@angular/core": "^16.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -898,9 +898,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.1.tgz",
-      "integrity": "sha512-druackA5JQpvfS8cD8DFtPRXGRKbhx3mQ778t1n6x3fXpIdGaAX+nSAgAKhIoF7fxWmu0KuHGzb+3BFlZRyTXw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.2.tgz",
+      "integrity": "sha512-2ww8/heDHkfJEBwjakbQeleq610ljcvytNs6ZN1xiXib060xMP+xx17Oa9I3onhi369JsKCHkMR5Qs2U5af1uA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -909,14 +909,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.1",
+        "@angular/core": "16.2.2",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.1.tgz",
-      "integrity": "sha512-dPauu+ESn79d66U9nBvnunNuBk/UMqnm7iL9Q31J8OKYN/4vrKbsO57pmULOft/GRAYsE3FdLBH0NkocFZKIMQ==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.2.tgz",
+      "integrity": "sha512-0X9i5NsqjX++0gmFy0fy2Uc5dHJMxDq6Yu/j1L3RdbvycL1GW+P8GgPfIvD/+v/YiDqpOHQswQXLbkcHw1+svA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -925,7 +925,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.1"
+        "@angular/core": "16.2.2"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.1.tgz",
-      "integrity": "sha512-A5SyNZTZnXSCL5JVXHKbYj9p2dRYoeFnb6hGQFt2AuCcpUjVIIdwHtre3YzkKe5sFwepPctdoRe2fRXlTfTRjA==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.2.tgz",
+      "integrity": "sha512-+4i7o0yBc6xSljO8rdYL1G9AiZr2OW5dJAHfPuO21yNhp9BjIJ/TW+Sw1+o/WH4Gnim9adtnonL18UM+vuYeXg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.22.5",
@@ -957,14 +957,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.2.1",
+        "@angular/compiler": "16.2.2",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.1.tgz",
-      "integrity": "sha512-Y+0jssQnJPovxMv9cDKYlp6BBHeFBLOHd/+FPv5IIGD1c7NwBP/TImJxCaIV78a57xnO8L0SFacDg/kULzvKrg==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.2.tgz",
+      "integrity": "sha512-l6nJlppguroov7eByBIpbxn/mEPcQrL//Ru1TSPzTtXOLR1p41VqPMaeJXj7xYVx7im57YLTDPAjhtLzkUT/Ow==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -978,9 +978,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.1.tgz",
-      "integrity": "sha512-SH8zRiRAcw0B5/tVlEc5U/lN5F8g+JizSuu7BQvpCAQEDkM6IjF9LP36Bjav7JuadItbWLfT6peWYa1sJvax2w==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.2.tgz",
+      "integrity": "sha512-9RwUiHYCAmEirXqwWL/rPfXHMkU9PnpGinok6tmHF8agAmJs1kMWZedxG0GnreTzpTlBu/dI/4v6VDfR9S/D6Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -989,9 +989,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.2.1",
-        "@angular/common": "16.2.1",
-        "@angular/core": "16.2.1"
+        "@angular/animations": "16.2.2",
+        "@angular/common": "16.2.2",
+        "@angular/core": "16.2.2"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.1.tgz",
-      "integrity": "sha512-dKMCSrbD/joOMXM1mhDOKNDZ1BxwO9r9uu5ZxY0L/fWm/ousgMucNikLr38vBudgWM8CN6BuabzkxWKcqi3k4g==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.2.tgz",
+      "integrity": "sha512-EOGDZ+oABB/aNiBR//wxc6McycjF99/9ds74Q6WoHiNy8CYkzH3plr5pHoy4zkriSyqzoETg2tCu7jSiiMbjRg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1011,10 +1011,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.2.1",
-        "@angular/compiler": "16.2.1",
-        "@angular/core": "16.2.1",
-        "@angular/platform-browser": "16.2.1"
+        "@angular/common": "16.2.2",
+        "@angular/compiler": "16.2.2",
+        "@angular/core": "16.2.2",
+        "@angular/platform-browser": "16.2.2"
       }
     },
     "node_modules/@assemblyscript/loader": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.2.1"
+    "@angular/core": "^16.2.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^16.2.0",
@@ -37,11 +37,11 @@
     "@angular-eslint/schematics": "^16.1.1",
     "@angular-eslint/template-parser": "^16.1.1",
     "@angular/cli": "^16.2.0",
-    "@angular/common": "^16.2.1",
-    "@angular/compiler": "^16.2.1",
-    "@angular/compiler-cli": "^16.2.1",
-    "@angular/platform-browser": "^16.2.1",
-    "@angular/platform-browser-dynamic": "^16.2.1",
+    "@angular/common": "^16.2.2",
+    "@angular/compiler": "^16.2.2",
+    "@angular/compiler-cli": "^16.2.2",
+    "@angular/platform-browser": "^16.2.2",
+    "@angular/platform-browser-dynamic": "^16.2.2",
     "@types/jasmine": "^4.3.5",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^20.5.6",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/core                           16.2.1 -> 16.2.2         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>