### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,17 @@
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^16.2.1",
-        "@angular-eslint/builder": "^16.1.1",
-        "@angular-eslint/eslint-plugin": "^16.1.1",
-        "@angular-eslint/eslint-plugin-template": "^16.1.1",
-        "@angular-eslint/schematics": "^16.1.1",
-        "@angular-eslint/template-parser": "^16.1.1",
+        "@angular-eslint/builder": "^16.1.2",
+        "@angular-eslint/eslint-plugin": "^16.1.2",
+        "@angular-eslint/eslint-plugin-template": "^16.1.2",
+        "@angular-eslint/schematics": "^16.1.2",
+        "@angular-eslint/template-parser": "^16.1.2",
         "@angular/cli": "^16.2.1",
-        "@angular/common": "^16.2.3",
-        "@angular/compiler": "^16.2.3",
-        "@angular/compiler-cli": "^16.2.3",
-        "@angular/platform-browser": "^16.2.3",
-        "@angular/platform-browser-dynamic": "^16.2.3",
+        "@angular/common": "^16.2.4",
+        "@angular/compiler": "^16.2.4",
+        "@angular/compiler-cli": "^16.2.4",
+        "@angular/platform-browser": "^16.2.4",
+        "@angular/platform-browser-dynamic": "^16.2.4",
         "@types/jasmine": "^4.3.5",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "^20.5.9",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.1"
       },
       "peerDependencies": {
-        "@angular/core": "^16.2.3"
+        "@angular/core": "^16.2.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@angular-eslint/builder": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-16.1.1.tgz",
-      "integrity": "sha512-NaB/A0mmlzp7laiucRUsRyoCrOE1In3UifsGP0vD6yjUpefk4g0v+0vCg8mhsIky8gYDtBE9YRfUiLA9FlF/FA==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-16.1.2.tgz",
+      "integrity": "sha512-Y95IBEWqzWA7SyIh5nlPuFasw/4lOILrAdY5Ji6tOpIJgNFoiR9K1UcH46i34r3384ApN8GEQJ7FlK6D6qCOJA==",
       "dev": true,
       "dependencies": {
         "@nx/devkit": "16.5.1",
@@ -733,18 +733,18 @@
       }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-16.1.1.tgz",
-      "integrity": "sha512-TB01AWZBDfrZBxN1I50HfBXtC7q4NI5fwl1aS4tOfef2/kQjTtR9zmha8CsxjDkAOa9tA/4MUayAMqEBQLuHKQ==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-16.1.2.tgz",
+      "integrity": "sha512-wDiHPFsKTijMcQUPNcoHOJ5kezIPCCbmDK6LHH7hAdAC/eDY9NHL5e4zQ2Xkf3/r1PFuwVLGTwwreEHlmeENDw==",
       "dev": true
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-16.1.1.tgz",
-      "integrity": "sha512-GauEwFGEcgIdsld4cVarFJYYxaRbMLzbpxyvBUDFg4LNjlcQNt7zfqXRLJoZAaFJFPtGtAoo1+6BlEKErsntuQ==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-16.1.2.tgz",
+      "integrity": "sha512-lYVvoKUIOg/ez15yfN4zY2A++vnIeJe1xh2ADNTmmjSh2PFV24K9YOgrTbgrY3Ul9kzGDTBkvYqslq+IvMGdIw==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/utils": "16.1.1",
+        "@angular-eslint/utils": "16.1.2",
         "@typescript-eslint/utils": "5.62.0"
       },
       "peerDependencies": {
@@ -753,13 +753,13 @@
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-16.1.1.tgz",
-      "integrity": "sha512-hwbpiUxLIY3TnZycieh+G4fbTWGMfzKx076O5Vuh2H4ZfXfs6ZXoi3Z0TH6X9lTmdgrwzOg1v4o5kdqu7MqPBg==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-16.1.2.tgz",
+      "integrity": "sha512-2qsoUgPg9Qp4EVUJRwWcJ+8JMxBb0ma3pNBjFmY6LOd59igRYorJKfWep4Nln1EicYRDRsCLzeLHO976+b1yaQ==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "16.1.1",
-        "@angular-eslint/utils": "16.1.1",
+        "@angular-eslint/bundled-angular-compiler": "16.1.2",
+        "@angular-eslint/utils": "16.1.2",
         "@typescript-eslint/type-utils": "5.62.0",
         "@typescript-eslint/utils": "5.62.0",
         "aria-query": "5.3.0",
@@ -771,13 +771,13 @@
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-16.1.1.tgz",
-      "integrity": "sha512-KlR01gpURPjz5OcoEvmKv3zi8l6lFpXYmqkXbGMCz828QlqBz1X7iGLAPJki+WUFSFKbRsf4qqaWq6O/8vph7Q==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-16.1.2.tgz",
+      "integrity": "sha512-319i47NU6nfaAaQTQYN7k320proTIBCueWGt+fbT11210CMqQriFmD+B85AatCwQgMgLd8Rhs1/F7YL2OOhegA==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/eslint-plugin": "16.1.1",
-        "@angular-eslint/eslint-plugin-template": "16.1.1",
+        "@angular-eslint/eslint-plugin": "16.1.2",
+        "@angular-eslint/eslint-plugin-template": "16.1.2",
         "@nx/devkit": "16.5.1",
         "ignore": "5.2.4",
         "nx": "16.5.1",
@@ -800,12 +800,12 @@
       }
     },
     "node_modules/@angular-eslint/template-parser": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-16.1.1.tgz",
-      "integrity": "sha512-ZJ+M4+JGYcsIP/t+XiuzL5A5pCjjCen272U3/M/WqIMDDxyIKrHubK1bVtr2kndCEudqud+WyJU0ub13UIwGgw==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-16.1.2.tgz",
+      "integrity": "sha512-vIkPOShVJLBEHYY3jISCVvJF3lXL//Y70J8T9lY2CBowgqp6AzzJ6cZU7JxrORN6b64rBUVvUtCGo8L36GvfuA==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "16.1.1",
+        "@angular-eslint/bundled-angular-compiler": "16.1.2",
         "eslint-scope": "^7.0.0"
       },
       "peerDependencies": {
@@ -836,12 +836,12 @@
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-16.1.1.tgz",
-      "integrity": "sha512-cmSTyFFY2TMLjhKdju0KQ9GB6nnXt1AbY9tZ0UtWGo3NKbrBUogc+PR9ma17VRAGhvdj/sSVkStphJH3F7rUgQ==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-16.1.2.tgz",
+      "integrity": "sha512-2yfEK3BPSJsUhP4JCz0EB6ktu4E4+/zc9qdtZvPWNF/eww2J/oYVPjY47C/HVg4MXpjJTI8vbdkvcnxrICIkfw==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "16.1.1",
+        "@angular-eslint/bundled-angular-compiler": "16.1.2",
         "@typescript-eslint/utils": "5.62.0"
       },
       "peerDependencies": {
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.3.tgz",
-      "integrity": "sha512-hOC2yqISBRAzltuVJQ3CEJxHRp9mWggysp0or5HydbcmvB6WIroECL7U0u36VA95zC9SXnymHA13OwiFPpmahA==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.4.tgz",
+      "integrity": "sha512-MsZfO/XedwL/3WKMgvefLOKz6w/eRQuRUYjhJtjCImqQB7evDLohjgfNY0tYPeyr1a+N6ekMyFbIAJdKlirOsg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -910,14 +910,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.3",
+        "@angular/core": "16.2.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.3.tgz",
-      "integrity": "sha512-bFc7YRHNdBJZD2HiORBQun2p40emvEt8D4JwXnW1JIStAWKJOXLyEjx045wNddqH7NpUq8AE2F1i82hIDNQZ1g==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.4.tgz",
+      "integrity": "sha512-MzvMFqfyrUfhCC+wtvzgbUrlksSpOSMeVwxDL1cwBrwGvprOjb4BeyjFx9XAsNhdA7vdUmaw9REJ8dOSeHpHyg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -926,7 +926,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.3"
+        "@angular/core": "16.2.4"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.3.tgz",
-      "integrity": "sha512-4p1tDeeONiq/zceC0T6unXDuqyWiAe7v2Ag7+ewwM9V8BF+YOEpEI/41lxzmbK2U1YUvG3jWfZyw3ertQlMp0Q==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.4.tgz",
+      "integrity": "sha512-pm4GpmZVEbibnXPb8hcFSdORmtHGX9GqPle0X/ydXAExLfSg7BIgfeEb/nDuStu6U+96gBA2fjX3jnhmhgFh/Q==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.22.5",
@@ -958,14 +958,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.2.3",
+        "@angular/compiler": "16.2.4",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.3.tgz",
-      "integrity": "sha512-YCzm7Rd2l0Ti0dZ1Mw3OfoQqlLolDN6jBEPy9Ah1s/KB+jKwNK9An3g8A9H6/jQIFwHCtxRad3LYH5ftknNMBQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.4.tgz",
+      "integrity": "sha512-8A1WGGvsKbwSEKoa1y6yBHgOBgv/4hCMo01HJv6BR9ApBjsjpBjXG3ltfRq293j9NF8tSu6gQMs7jrc2uVXZCg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.3.tgz",
-      "integrity": "sha512-adWINGgjIMxwbWJhkMwpEfb4FRFMda5X6ahxWQX2E03Nl0kzePI6cvlJqAgp+iBwTkieWeU8BThJk2/rMkS3bw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.4.tgz",
+      "integrity": "sha512-1Mw7bD1TE1XtrMLPhqHjvd/TIHY9dEEnDzTHWajhaj4PCQ+eh4jF9X4mzU5K2RNJjbyTNf0ikbg18RGZSyHtpw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -990,9 +990,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.2.3",
-        "@angular/common": "16.2.3",
-        "@angular/core": "16.2.3"
+        "@angular/animations": "16.2.4",
+        "@angular/common": "16.2.4",
+        "@angular/core": "16.2.4"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.3.tgz",
-      "integrity": "sha512-Y3cYob1VGzT1xSMbuLGVxPlyuhv4zshYEo/yy2626YD63DigqYwGzj+gT0JoU1eNuXw2UWp3R67d9F8SC015Jw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.4.tgz",
+      "integrity": "sha512-/xSRRX+lKj+7cIQIkdKWfbfAYNNOQoC1Qq3dehLeld9si0gxrL6N03y8UaSd7CTo96JlNxdpzI+LoE44bRQs8A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1012,10 +1012,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.2.3",
-        "@angular/compiler": "16.2.3",
-        "@angular/core": "16.2.3",
-        "@angular/platform-browser": "16.2.3"
+        "@angular/common": "16.2.4",
+        "@angular/compiler": "16.2.4",
+        "@angular/core": "16.2.4",
+        "@angular/platform-browser": "16.2.4"
       }
     },
     "node_modules/@assemblyscript/loader": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.2.3"
+    "@angular/core": "^16.2.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^16.2.1",
-    "@angular-eslint/builder": "^16.1.1",
-    "@angular-eslint/eslint-plugin": "^16.1.1",
-    "@angular-eslint/eslint-plugin-template": "^16.1.1",
-    "@angular-eslint/schematics": "^16.1.1",
-    "@angular-eslint/template-parser": "^16.1.1",
+    "@angular-eslint/builder": "^16.1.2",
+    "@angular-eslint/eslint-plugin": "^16.1.2",
+    "@angular-eslint/eslint-plugin-template": "^16.1.2",
+    "@angular-eslint/schematics": "^16.1.2",
+    "@angular-eslint/template-parser": "^16.1.2",
     "@angular/cli": "^16.2.1",
-    "@angular/common": "^16.2.3",
-    "@angular/compiler": "^16.2.3",
-    "@angular/compiler-cli": "^16.2.3",
-    "@angular/platform-browser": "^16.2.3",
-    "@angular/platform-browser-dynamic": "^16.2.3",
+    "@angular/common": "^16.2.4",
+    "@angular/compiler": "^16.2.4",
+    "@angular/compiler-cli": "^16.2.4",
+    "@angular/platform-browser": "^16.2.4",
+    "@angular/platform-browser-dynamic": "^16.2.4",
     "@types/jasmine": "^4.3.5",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^20.5.9",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular-eslint/schematics              16.1.1 -> 16.1.2         ng update @angular-eslint/schematics
      @angular/core                           16.2.3 -> 16.2.4         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>