### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^16.2.4",
+        "@angular-devkit/build-angular": "^16.2.5",
         "@angular-eslint/builder": "^16.2.0",
         "@angular-eslint/eslint-plugin": "^16.2.0",
         "@angular-eslint/eslint-plugin-template": "^16.2.0",
         "@angular-eslint/schematics": "^16.2.0",
         "@angular-eslint/template-parser": "^16.2.0",
-        "@angular/cli": "^16.2.4",
-        "@angular/common": "^16.2.7",
-        "@angular/compiler": "^16.2.7",
-        "@angular/compiler-cli": "^16.2.7",
-        "@angular/platform-browser": "^16.2.7",
-        "@angular/platform-browser-dynamic": "^16.2.7",
+        "@angular/cli": "^16.2.5",
+        "@angular/common": "^16.2.8",
+        "@angular/compiler": "^16.2.8",
+        "@angular/compiler-cli": "^16.2.8",
+        "@angular/platform-browser": "^16.2.8",
+        "@angular/platform-browser-dynamic": "^16.2.8",
         "@types/jasmine": "^5.1.0",
         "@types/jasminewd2": "~2.0.11",
         "@types/node": "^20.8.2",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.3"
       },
       "peerDependencies": {
-        "@angular/core": "^16.2.7"
+        "@angular/core": "^16.2.8"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1602.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.4.tgz",
-      "integrity": "sha512-SQr/FZ8wEOGC6EM+7V5rWyb/qpK0LFND/WbES5l+Yvwv+TEyPihsh5QCPmvPxi45eFbaHPrXkIZnvxnkxRDN/A==",
+      "version": "0.1602.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.5.tgz",
+      "integrity": "sha512-lbFA2nrF0A1Rs6AU9yYeSHflsiorqL4tSwL7wMtQWMNawRjORiY7IwETyL0PmnlKsbbPlTGnWBhMfeGyBOowEw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.4",
+        "@angular-devkit/core": "16.2.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.4.tgz",
-      "integrity": "sha512-qWWjw321+qKzQ3U+arPJ5fdqxZ/aeT5HuxAtA7xqNu/cqnqvRZ8RVbbnugFx4U1R271tABT+N+N1kkIep/vlDg==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.5.tgz",
+      "integrity": "sha512-ZHyMhhSZkulJiDyTvONJV2OwbxTdjbrJGfkUhv4k4f4HfV8ADUXlhanGjuqykxWG2CmDIsV09j/5b1lg2fYqww==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1602.4",
-        "@angular-devkit/build-webpack": "0.1602.4",
-        "@angular-devkit/core": "16.2.4",
+        "@angular-devkit/architect": "0.1602.5",
+        "@angular-devkit/build-webpack": "0.1602.5",
+        "@angular-devkit/core": "16.2.5",
         "@babel/core": "7.22.9",
         "@babel/generator": "7.22.9",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -109,7 +109,7 @@
         "@babel/runtime": "7.22.6",
         "@babel/template": "7.22.5",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "16.2.4",
+        "@ngtools/webpack": "16.2.5",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.14",
@@ -139,7 +139,7 @@
         "parse5-html-rewriting-stream": "7.0.0",
         "picomatch": "2.3.1",
         "piscina": "4.0.0",
-        "postcss": "8.4.27",
+        "postcss": "8.4.31",
         "postcss-loader": "7.3.3",
         "resolve-url-loader": "5.0.0",
         "rxjs": "7.8.1",
@@ -655,12 +655,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1602.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.4.tgz",
-      "integrity": "sha512-QOnMfAOFrAQKOw+odgymragqzv6Ts5/Ni7/SJ1iLwlQcH6TajT6373fSCDFdKV40ntF53yjnexIsLx81/dK+Cg==",
+      "version": "0.1602.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.5.tgz",
+      "integrity": "sha512-cpdhZdi1I3/gu3wcwQyIstrbE0kpoa5vvHu9MFzQ9a/DZV0aAev2d1e9rgOwSRUTCB83LV8+eBY99jqmF54U/g==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.4",
+        "@angular-devkit/architect": "0.1602.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.4.tgz",
-      "integrity": "sha512-VCZ1z1lDbFkbYkQ6ZMEFfmNzkMEOCBKSzAhWutRyd7oM02by4/5SvDSXd5BMvMxWhPJ/567DdSPOfhhnXQkkDg==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.5.tgz",
+      "integrity": "sha512-d7xzdvv3aZiNgMtFERR3TxUAdKjzWiWUN94jjBeovITP32yFDz02DzXwUGMFIA3/YhZ/sAEEOKVF3pBXLJ6P4g==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -701,12 +701,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.4.tgz",
-      "integrity": "sha512-TsSflKJlaHzKgcU/taQg5regmBP/ggvwVtAbJRBWmCaeQJzobFo68+rtwfYfvuQXKAR6KsbSJc97mqmq6zmTwQ==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.5.tgz",
+      "integrity": "sha512-Du2qaN4SVrtPe2jQuo0VVZgFCUwouyv7tTwyJXv32Kvfw9s3IQD/yYSh0H+XTEbplUV9Fc8b9zWaVhVY1yvrSw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.4",
+        "@angular-devkit/core": "16.2.5",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.1",
         "ora": "5.4.1",
@@ -850,15 +850,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.4.tgz",
-      "integrity": "sha512-OjnlQ2wzhkc1q3iDbWtLeaXoPzS0BtevazT7vmB/MiNVgjDcF3bPFQTcBBvtWAF0wN9jgPC712X8ucwdEAOMlg==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.5.tgz",
+      "integrity": "sha512-7+OG2KKUq+Wi9pl8JJKzH5BICOInMvyRma8/anDiXMTdhuO8cyhPu3xCl8znc6qV9RcUax0HvJmRq11kv/aJTA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.4",
-        "@angular-devkit/core": "16.2.4",
-        "@angular-devkit/schematics": "16.2.4",
-        "@schematics/angular": "16.2.4",
+        "@angular-devkit/architect": "0.1602.5",
+        "@angular-devkit/core": "16.2.5",
+        "@angular-devkit/schematics": "16.2.5",
+        "@schematics/angular": "16.2.5",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.7.tgz",
-      "integrity": "sha512-vcKbbtDXNmJ8dj1GF52saJRT5U3P+phnIwnv+hQ2c+VVj/S2alWlBkT12iM+KlvnWdxsa0q4yW0G4WvpPJPaMQ==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.8.tgz",
+      "integrity": "sha512-0LZSBHnk9c6XPcrQx9D8i0DKi807IuiuOtK4kMa64aj1pySY3TK+uort5hqpmhgdqiCbBHZjgpRpU83LoTTl3w==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -910,14 +910,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.7",
+        "@angular/core": "16.2.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.7.tgz",
-      "integrity": "sha512-Sp+QjHFYjBMhjag/YbIV5skqr/UrpBjCPo1WFBBhj5DKkvgWC7T00yYJn+aBj0DU5ZuMmO/P8Vb7bRIHIRNL4w==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.8.tgz",
+      "integrity": "sha512-xWdMAeBkYh8ESk9iBSYnp2qfbGPNReggtNJuUL9I7AFGkzkvEWndyQ+oTXzCM5gjj4nWB5A/AAYYDU54sDac2Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -926,7 +926,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.7"
+        "@angular/core": "16.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.7.tgz",
-      "integrity": "sha512-aMAmSyurmvdKIcRpATfJPyTa0RYOylmXb7TI5TyDico9pUR7RAlreuW/1NUeIPWfZdPrPyoGOYGqukSuSnyrNA==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.8.tgz",
+      "integrity": "sha512-kKcfr8vbdB+MYDgyeZdxeoVbOpoGFmxOj4IEVnOQ2SPYexcnLEK38qect6LpHGIEG5bOQrkQqWmNnmHAEH4L1g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.22.5",
@@ -958,14 +958,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.2.7",
+        "@angular/compiler": "16.2.8",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.7.tgz",
-      "integrity": "sha512-JQOxo+Ja9ThQjUa4vdOMLZfIK2dhR3cnPbqB1tV2WuTmIv49QASbFHsae8zZsS4Au5/TafBaW3KkK9aRU8G5gg==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.8.tgz",
+      "integrity": "sha512-v3kwZsjf7mKBGMky+UfxV3iwA1BFy1c3gmjyHSPSll9TPr2jkfwstoB2Cc+wmS2S9ezHFAMX++XXRymKVRQzQg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.7.tgz",
-      "integrity": "sha512-yQ/4FB33Jc1Xs+slWfddZpbKdkCHdhCh39Mfjxa1wTen6YJZKmvjBbMNCkvnvNbLqc2IFWRwTQdG8s0n1jfl3A==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.8.tgz",
+      "integrity": "sha512-y0rt8HmnTjvZrqt+bKU5CnmaI7xQiRWIaLWpYXGgqcqqMDgMYwSm2lV3H6K6S1v0ut+Q+zIWj2rGjr8Apox34Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -990,9 +990,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.2.7",
-        "@angular/common": "16.2.7",
-        "@angular/core": "16.2.7"
+        "@angular/animations": "16.2.8",
+        "@angular/common": "16.2.8",
+        "@angular/core": "16.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.7.tgz",
-      "integrity": "sha512-raeuYEQfByHByLnA5YRR7fYD/5u6hMjONH77p08IjmtdmLb0XYP18l/C4YqsIOQG6kZLNCVWknEHZu3kuvAwtQ==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.8.tgz",
+      "integrity": "sha512-METr1TuMP2fHOXN0wVlW4CpQEIvy5fLSsPprDPuL+C0KeaCLuTST9Ek+yL7IVGu+VIpFZuqMC376z8n6ENo97g==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1012,10 +1012,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.2.7",
-        "@angular/compiler": "16.2.7",
-        "@angular/core": "16.2.7",
-        "@angular/platform-browser": "16.2.7"
+        "@angular/common": "16.2.8",
+        "@angular/compiler": "16.2.8",
+        "@angular/core": "16.2.8",
+        "@angular/platform-browser": "16.2.8"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3528,9 +3528,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.4.tgz",
-      "integrity": "sha512-ILri2xJ6vMUaFxHJABGF/H7/pYoBkuXTFlHCeFee9pHA+EHkxoiwezLf8baiFT3IGOmdG6GOUlfh/4QicGLdTQ==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.5.tgz",
+      "integrity": "sha512-wq1dbbOUwrY/zkpZltcgmyEFANbJon79E5s4ueT3IT4NyiYh1uJeWa2vmB0kof7VP5Xhm/jutkJk336z67oLPg==",
       "dev": true,
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -4081,13 +4081,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.4.tgz",
-      "integrity": "sha512-ZFPxn0yihdNcg5UpJvnfxIpv4GuW6nYDkgeIlYb5k/a0dKSW8wE8Akcl1JhJtdKJ0RVcn1OwZDmx028JCbZJLA==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.5.tgz",
+      "integrity": "sha512-huYEiU5KK2/upy9LJUdecIB4Jwh4LQMQz5cz6EMr8uhrCTykEKXlBpGJVHZyDK1K5/riymSr9G86BdN2PcY1Cw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.4",
-        "@angular-devkit/schematics": "16.2.4",
+        "@angular-devkit/core": "16.2.5",
+        "@angular-devkit/schematics": "16.2.5",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -11914,13 +11914,13 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
-      "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
+      "integrity": "sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==",
       "dev": true,
       "dependencies": {
         "picocolors": "^1.0.0",
-        "shell-quote": "^1.7.3"
+        "shell-quote": "^1.8.1"
       }
     },
     "node_modules/less": {
@@ -14672,9 +14672,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.2.7"
+    "@angular/core": "^16.2.8"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.2.4",
+    "@angular-devkit/build-angular": "^16.2.5",
     "@angular-eslint/builder": "^16.2.0",
     "@angular-eslint/eslint-plugin": "^16.2.0",
     "@angular-eslint/eslint-plugin-template": "^16.2.0",
     "@angular-eslint/schematics": "^16.2.0",
     "@angular-eslint/template-parser": "^16.2.0",
-    "@angular/cli": "^16.2.4",
-    "@angular/common": "^16.2.7",
-    "@angular/compiler": "^16.2.7",
-    "@angular/compiler-cli": "^16.2.7",
-    "@angular/platform-browser": "^16.2.7",
-    "@angular/platform-browser-dynamic": "^16.2.7",
+    "@angular/cli": "^16.2.5",
+    "@angular/common": "^16.2.8",
+    "@angular/compiler": "^16.2.8",
+    "@angular/compiler-cli": "^16.2.8",
+    "@angular/platform-browser": "^16.2.8",
+    "@angular/platform-browser-dynamic": "^16.2.8",
     "@types/jasmine": "^5.1.0",
     "@types/jasminewd2": "~2.0.11",
     "@types/node": "^20.8.2",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            16.2.4 -> 16.2.5         ng update @angular/cli
      @angular/core                           16.2.7 -> 16.2.8         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>