### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^16.2.5",
+        "@angular-devkit/build-angular": "^16.2.6",
         "@angular-eslint/builder": "^16.2.0",
         "@angular-eslint/eslint-plugin": "^16.2.0",
         "@angular-eslint/eslint-plugin-template": "^16.2.0",
         "@angular-eslint/schematics": "^16.2.0",
         "@angular-eslint/template-parser": "^16.2.0",
-        "@angular/cli": "^16.2.5",
-        "@angular/common": "^16.2.8",
-        "@angular/compiler": "^16.2.8",
-        "@angular/compiler-cli": "^16.2.8",
-        "@angular/platform-browser": "^16.2.8",
-        "@angular/platform-browser-dynamic": "^16.2.8",
+        "@angular/cli": "^16.2.6",
+        "@angular/common": "^16.2.9",
+        "@angular/compiler": "^16.2.9",
+        "@angular/compiler-cli": "^16.2.9",
+        "@angular/platform-browser": "^16.2.9",
+        "@angular/platform-browser-dynamic": "^16.2.9",
         "@types/jasmine": "^5.1.0",
         "@types/jasminewd2": "~2.0.11",
         "@types/node": "^20.8.5",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.3"
       },
       "peerDependencies": {
-        "@angular/core": "^16.2.8"
+        "@angular/core": "^16.2.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1602.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.5.tgz",
-      "integrity": "sha512-lbFA2nrF0A1Rs6AU9yYeSHflsiorqL4tSwL7wMtQWMNawRjORiY7IwETyL0PmnlKsbbPlTGnWBhMfeGyBOowEw==",
+      "version": "0.1602.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.6.tgz",
+      "integrity": "sha512-b1NNV3yNg6Rt86ms20bJIroWUI8ihaEwv5k+EoijEXLoMs4eNs5PhqL+QE8rTj+q9pa1gSrWf2blXor2JGwf1g==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.5",
+        "@angular-devkit/core": "16.2.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.5.tgz",
-      "integrity": "sha512-ZHyMhhSZkulJiDyTvONJV2OwbxTdjbrJGfkUhv4k4f4HfV8ADUXlhanGjuqykxWG2CmDIsV09j/5b1lg2fYqww==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.6.tgz",
+      "integrity": "sha512-QdU/q77K1P8CPEEZGxw1QqLcnA9ofboDWS7vcLRBmFmk2zydtLTApbK0P8GNDRbnmROOKkoaLo+xUTDJz9gvPA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1602.5",
-        "@angular-devkit/build-webpack": "0.1602.5",
-        "@angular-devkit/core": "16.2.5",
+        "@angular-devkit/architect": "0.1602.6",
+        "@angular-devkit/build-webpack": "0.1602.6",
+        "@angular-devkit/core": "16.2.6",
         "@babel/core": "7.22.9",
         "@babel/generator": "7.22.9",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -109,7 +109,7 @@
         "@babel/runtime": "7.22.6",
         "@babel/template": "7.22.5",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "16.2.5",
+        "@ngtools/webpack": "16.2.6",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.14",
@@ -655,12 +655,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1602.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.5.tgz",
-      "integrity": "sha512-cpdhZdi1I3/gu3wcwQyIstrbE0kpoa5vvHu9MFzQ9a/DZV0aAev2d1e9rgOwSRUTCB83LV8+eBY99jqmF54U/g==",
+      "version": "0.1602.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.6.tgz",
+      "integrity": "sha512-BJPR6xdq7gRJ6bVWnZ81xHyH75j7lyLbegCXbvUNaM8TWVBkwWsSdqr2NQ717dNLLn5umg58SFpU/pWMq6CxMQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.5",
+        "@angular-devkit/architect": "0.1602.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.5.tgz",
-      "integrity": "sha512-d7xzdvv3aZiNgMtFERR3TxUAdKjzWiWUN94jjBeovITP32yFDz02DzXwUGMFIA3/YhZ/sAEEOKVF3pBXLJ6P4g==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.6.tgz",
+      "integrity": "sha512-iez/8NYXQT6fqVQLlKmZUIRkFUEZ88ACKbTwD4lBmk0+hXW+bQBxI7JOnE3C4zkcM2YeuTXIYsC5SebTKYiR4Q==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -701,12 +701,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.5.tgz",
-      "integrity": "sha512-Du2qaN4SVrtPe2jQuo0VVZgFCUwouyv7tTwyJXv32Kvfw9s3IQD/yYSh0H+XTEbplUV9Fc8b9zWaVhVY1yvrSw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.6.tgz",
+      "integrity": "sha512-PhpRYHCJ3WvZXmng6Qk8TXeQf83jeBMAf7AIzI8h0fgeBocOl97Xf7bZpLg6GymiU+rVn15igQ4Rz9rKAay8bQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.5",
+        "@angular-devkit/core": "16.2.6",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.1",
         "ora": "5.4.1",
@@ -850,15 +850,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.5.tgz",
-      "integrity": "sha512-7+OG2KKUq+Wi9pl8JJKzH5BICOInMvyRma8/anDiXMTdhuO8cyhPu3xCl8znc6qV9RcUax0HvJmRq11kv/aJTA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.6.tgz",
+      "integrity": "sha512-9poPvUEmlufOAW1Cjk+aA5e2x3mInLtbYYSL/EYviDN2ugmavsSIvxAE/WLnxq6cPWqhNDbHDaqvcmqkcFM3Cw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.5",
-        "@angular-devkit/core": "16.2.5",
-        "@angular-devkit/schematics": "16.2.5",
-        "@schematics/angular": "16.2.5",
+        "@angular-devkit/architect": "0.1602.6",
+        "@angular-devkit/core": "16.2.6",
+        "@angular-devkit/schematics": "16.2.6",
+        "@schematics/angular": "16.2.6",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.8.tgz",
-      "integrity": "sha512-0LZSBHnk9c6XPcrQx9D8i0DKi807IuiuOtK4kMa64aj1pySY3TK+uort5hqpmhgdqiCbBHZjgpRpU83LoTTl3w==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.9.tgz",
+      "integrity": "sha512-5Lh5KsxCkaoBDeSAghKNF5lCi0083ug4X2X7wnafsSd6Z3xt/rDjH9hDOP5SF5IDLtCVjJgHfs3cCLSTjRuNwg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -910,14 +910,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.8",
+        "@angular/core": "16.2.9",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.8.tgz",
-      "integrity": "sha512-xWdMAeBkYh8ESk9iBSYnp2qfbGPNReggtNJuUL9I7AFGkzkvEWndyQ+oTXzCM5gjj4nWB5A/AAYYDU54sDac2Q==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.9.tgz",
+      "integrity": "sha512-lh799pnbdvzTVShJHOY1JC6c1pwBsZC4UIgB3Itklo9dskGybQma/gP+lE6RhqM4FblNfaaBXGlCMUuY8HkmEQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -926,7 +926,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.8"
+        "@angular/core": "16.2.9"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.8.tgz",
-      "integrity": "sha512-kKcfr8vbdB+MYDgyeZdxeoVbOpoGFmxOj4IEVnOQ2SPYexcnLEK38qect6LpHGIEG5bOQrkQqWmNnmHAEH4L1g==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.9.tgz",
+      "integrity": "sha512-ecH2oOlijJdDqioD9IfgdqJGoRRHI6hAx5rwBxIaYk01ywj13KzvXWPrXbCIupeWtV/XUZUlbwf47nlmL5gxZg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.22.5",
@@ -958,14 +958,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.2.8",
+        "@angular/compiler": "16.2.9",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.8.tgz",
-      "integrity": "sha512-v3kwZsjf7mKBGMky+UfxV3iwA1BFy1c3gmjyHSPSll9TPr2jkfwstoB2Cc+wmS2S9ezHFAMX++XXRymKVRQzQg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.9.tgz",
+      "integrity": "sha512-chvPX29ZBcMDuh7rLIgb0Cru6oJ/0FaqRzfOI3wT4W2F9W1HOlCtipovzmPYaUAmXBWfVP4EBO9TOWnpog0S0w==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.8.tgz",
-      "integrity": "sha512-y0rt8HmnTjvZrqt+bKU5CnmaI7xQiRWIaLWpYXGgqcqqMDgMYwSm2lV3H6K6S1v0ut+Q+zIWj2rGjr8Apox34Q==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.9.tgz",
+      "integrity": "sha512-9Je7+Jmx0AOyRzBBumraVJG3M0R6YbT4c9jTUbLGJCcPxwDI3/u2ZzvW3rBqpmrDaqLxN5f1LcZeTZx287QeqQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -990,9 +990,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.2.8",
-        "@angular/common": "16.2.8",
-        "@angular/core": "16.2.8"
+        "@angular/animations": "16.2.9",
+        "@angular/common": "16.2.9",
+        "@angular/core": "16.2.9"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.8.tgz",
-      "integrity": "sha512-METr1TuMP2fHOXN0wVlW4CpQEIvy5fLSsPprDPuL+C0KeaCLuTST9Ek+yL7IVGu+VIpFZuqMC376z8n6ENo97g==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.9.tgz",
+      "integrity": "sha512-ztpo0939vTZ/5CWVSvo41Yl6YPoTZ0If+yTrs7dk1ce0vFgaZXMlc+y5ZwjJIiMM5CvHbhL48Uk+HJNIojP98A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1012,10 +1012,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.2.8",
-        "@angular/compiler": "16.2.8",
-        "@angular/core": "16.2.8",
-        "@angular/platform-browser": "16.2.8"
+        "@angular/common": "16.2.9",
+        "@angular/compiler": "16.2.9",
+        "@angular/core": "16.2.9",
+        "@angular/platform-browser": "16.2.9"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3528,9 +3528,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.5.tgz",
-      "integrity": "sha512-wq1dbbOUwrY/zkpZltcgmyEFANbJon79E5s4ueT3IT4NyiYh1uJeWa2vmB0kof7VP5Xhm/jutkJk336z67oLPg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.6.tgz",
+      "integrity": "sha512-d8ZlZL6dOtWmHdjG9PTGBkdiJMcsXD2tp6WeFRVvTEuvCI3XvKsUXBvJDE+mZOhzn5pUEYt+1TR5DHjDZbME3w==",
       "dev": true,
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -4081,13 +4081,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.5.tgz",
-      "integrity": "sha512-huYEiU5KK2/upy9LJUdecIB4Jwh4LQMQz5cz6EMr8uhrCTykEKXlBpGJVHZyDK1K5/riymSr9G86BdN2PcY1Cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.6.tgz",
+      "integrity": "sha512-fM09WPqST+nhVGV5Q3fhG7WKo96kgSVMsbz3wGS0DmTn4zge7ZWnrW3VvbxnMapmGoKa9DFPqdqNln4ADcdIMQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.5",
-        "@angular-devkit/schematics": "16.2.5",
+        "@angular-devkit/core": "16.2.6",
+        "@angular-devkit/schematics": "16.2.6",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -4264,9 +4264,9 @@
       "dev": true
     },
     "node_modules/@types/express": {
-      "version": "4.17.18",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
-      "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.19.tgz",
+      "integrity": "sha512-UtOfBtzN9OvpZPPbnnYunfjM7XCI4jyk1NvnFhTVz5krYAnW4o5DCoIekvms+8ApqhB4+9wSge1kBijdfTSmfg==",
       "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
@@ -4432,9 +4432,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
-      "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
+      "version": "8.5.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.7.tgz",
+      "integrity": "sha512-6UrLjiDUvn40CMrAubXuIVtj2PEfKDffJS7ychvnPU44j+KVeXmdHHTgqcM/dxLUTHxlXHiFM8Skmb8ozGdTnQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.2.8"
+    "@angular/core": "^16.2.9"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.2.5",
+    "@angular-devkit/build-angular": "^16.2.6",
     "@angular-eslint/builder": "^16.2.0",
     "@angular-eslint/eslint-plugin": "^16.2.0",
     "@angular-eslint/eslint-plugin-template": "^16.2.0",
     "@angular-eslint/schematics": "^16.2.0",
     "@angular-eslint/template-parser": "^16.2.0",
-    "@angular/cli": "^16.2.5",
-    "@angular/common": "^16.2.8",
-    "@angular/compiler": "^16.2.8",
-    "@angular/compiler-cli": "^16.2.8",
-    "@angular/platform-browser": "^16.2.8",
-    "@angular/platform-browser-dynamic": "^16.2.8",
+    "@angular/cli": "^16.2.6",
+    "@angular/common": "^16.2.9",
+    "@angular/compiler": "^16.2.9",
+    "@angular/compiler-cli": "^16.2.9",
+    "@angular/platform-browser": "^16.2.9",
+    "@angular/platform-browser-dynamic": "^16.2.9",
     "@types/jasmine": "^5.1.0",
     "@types/jasminewd2": "~2.0.11",
     "@types/node": "^20.8.5",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            16.2.5 -> 16.2.6         ng update @angular/cli
      @angular/core                           16.2.8 -> 16.2.9         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>