### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^16.2.6",
+        "@angular-devkit/build-angular": "^16.2.7",
         "@angular-eslint/builder": "^16.2.0",
         "@angular-eslint/eslint-plugin": "^16.2.0",
         "@angular-eslint/eslint-plugin-template": "^16.2.0",
         "@angular-eslint/schematics": "^16.2.0",
         "@angular-eslint/template-parser": "^16.2.0",
-        "@angular/cli": "^16.2.6",
-        "@angular/common": "^16.2.9",
-        "@angular/compiler": "^16.2.9",
-        "@angular/compiler-cli": "^16.2.9",
-        "@angular/platform-browser": "^16.2.9",
-        "@angular/platform-browser-dynamic": "^16.2.9",
+        "@angular/cli": "^16.2.7",
+        "@angular/common": "^16.2.10",
+        "@angular/compiler": "^16.2.10",
+        "@angular/compiler-cli": "^16.2.10",
+        "@angular/platform-browser": "^16.2.10",
+        "@angular/platform-browser-dynamic": "^16.2.10",
         "@types/jasmine": "^5.1.1",
         "@types/jasminewd2": "~2.0.12",
         "@types/node": "^20.8.7",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.3"
       },
       "peerDependencies": {
-        "@angular/core": "^16.2.9"
+        "@angular/core": "^16.2.10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1602.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.6.tgz",
-      "integrity": "sha512-b1NNV3yNg6Rt86ms20bJIroWUI8ihaEwv5k+EoijEXLoMs4eNs5PhqL+QE8rTj+q9pa1gSrWf2blXor2JGwf1g==",
+      "version": "0.1602.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.7.tgz",
+      "integrity": "sha512-r6+z4jRE+e9VNeTmJCGz5VI5azRagOqE4SIDqaywz75eHOJ9UPSo9MHy8zFw1eLt1WcvCDqk+Pk9+krh2E+B8Q==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.6",
+        "@angular-devkit/core": "16.2.7",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.6.tgz",
-      "integrity": "sha512-QdU/q77K1P8CPEEZGxw1QqLcnA9ofboDWS7vcLRBmFmk2zydtLTApbK0P8GNDRbnmROOKkoaLo+xUTDJz9gvPA==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.7.tgz",
+      "integrity": "sha512-OTH4qzXmWXifhvH0iXwPUhElWEU9SUcIZyWYbv2NR5ImAw/GE07vDuBljGRJeSEC9MpFbThwEFbHD8oRWiLUag==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1602.6",
-        "@angular-devkit/build-webpack": "0.1602.6",
-        "@angular-devkit/core": "16.2.6",
+        "@angular-devkit/architect": "0.1602.7",
+        "@angular-devkit/build-webpack": "0.1602.7",
+        "@angular-devkit/core": "16.2.7",
         "@babel/core": "7.22.9",
         "@babel/generator": "7.22.9",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -109,7 +109,7 @@
         "@babel/runtime": "7.22.6",
         "@babel/template": "7.22.5",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "16.2.6",
+        "@ngtools/webpack": "16.2.7",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.14",
@@ -655,12 +655,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1602.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.6.tgz",
-      "integrity": "sha512-BJPR6xdq7gRJ6bVWnZ81xHyH75j7lyLbegCXbvUNaM8TWVBkwWsSdqr2NQ717dNLLn5umg58SFpU/pWMq6CxMQ==",
+      "version": "0.1602.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.7.tgz",
+      "integrity": "sha512-3+MV9ehn65XUUMSBBgfg5K2zZs2jhif75ypI+BBUfZDUWeKR5MeGJy0aDHZ+2H94kPkmSD3PrkOuitWdnDjTgA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.6",
+        "@angular-devkit/architect": "0.1602.7",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.6.tgz",
-      "integrity": "sha512-iez/8NYXQT6fqVQLlKmZUIRkFUEZ88ACKbTwD4lBmk0+hXW+bQBxI7JOnE3C4zkcM2YeuTXIYsC5SebTKYiR4Q==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.7.tgz",
+      "integrity": "sha512-XskObYrg7NRdEuHnSVZOM7OeinEL8HzugjmKnawAa+dAbFCCoGsVWjMliA/Q8sb1yfGkyL0WW7DZABZj7EGwWA==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -701,12 +701,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.6.tgz",
-      "integrity": "sha512-PhpRYHCJ3WvZXmng6Qk8TXeQf83jeBMAf7AIzI8h0fgeBocOl97Xf7bZpLg6GymiU+rVn15igQ4Rz9rKAay8bQ==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.7.tgz",
+      "integrity": "sha512-zu3xHwA4w+kXHkyyjGl3i7uSU2/kKLPKuyyixw0WLcKUQCYd7TWmu8OC0qCDa42XkxP9gGL091dJFu56exgneA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.6",
+        "@angular-devkit/core": "16.2.7",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.1",
         "ora": "5.4.1",
@@ -850,15 +850,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.6.tgz",
-      "integrity": "sha512-9poPvUEmlufOAW1Cjk+aA5e2x3mInLtbYYSL/EYviDN2ugmavsSIvxAE/WLnxq6cPWqhNDbHDaqvcmqkcFM3Cw==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.7.tgz",
+      "integrity": "sha512-30yBAYzbrj/WM4tLiX4IU5byw0b5Y5LEzcpjYZglv/RXPrnevGlRXmgCulpt8wIdkd668N7kXEQ23nipuJDXMg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.6",
-        "@angular-devkit/core": "16.2.6",
-        "@angular-devkit/schematics": "16.2.6",
-        "@schematics/angular": "16.2.6",
+        "@angular-devkit/architect": "0.1602.7",
+        "@angular-devkit/core": "16.2.7",
+        "@angular-devkit/schematics": "16.2.7",
+        "@schematics/angular": "16.2.7",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.9.tgz",
-      "integrity": "sha512-5Lh5KsxCkaoBDeSAghKNF5lCi0083ug4X2X7wnafsSd6Z3xt/rDjH9hDOP5SF5IDLtCVjJgHfs3cCLSTjRuNwg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.10.tgz",
+      "integrity": "sha512-cLth66aboInNcWFjDBRmK30jC5KN10nKDDcv4U/r3TDTBpKOtnmTjNFFr7dmjfUmVhHFy/66piBMfpjZI93Rxg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -910,14 +910,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.9",
+        "@angular/core": "16.2.10",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.9.tgz",
-      "integrity": "sha512-lh799pnbdvzTVShJHOY1JC6c1pwBsZC4UIgB3Itklo9dskGybQma/gP+lE6RhqM4FblNfaaBXGlCMUuY8HkmEQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.10.tgz",
+      "integrity": "sha512-ty6SfqkZlV2bLU/SSi3wmxrEFgPrK+WVslCNIr3FlTnCBdqpIbadHN2QB3A1d9XaNc7c4Tq5DQKh34cwMwNbuw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -926,7 +926,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.9"
+        "@angular/core": "16.2.10"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -935,12 +935,12 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.9.tgz",
-      "integrity": "sha512-ecH2oOlijJdDqioD9IfgdqJGoRRHI6hAx5rwBxIaYk01ywj13KzvXWPrXbCIupeWtV/XUZUlbwf47nlmL5gxZg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.10.tgz",
+      "integrity": "sha512-swgmtm4R23vQV9nJTXdDEFpOyIw3kz80mdT9qo3VId/2rqenOK253JsFypoqEj/fKzjV9gwXtTbmrMlhVyuyxw==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "7.22.5",
+        "@babel/core": "7.23.2",
         "@jridgewell/sourcemap-codec": "^1.4.14",
         "chokidar": "^3.0.0",
         "convert-source-map": "^1.5.1",
@@ -958,14 +958,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.2.9",
+        "@angular/compiler": "16.2.10",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.9.tgz",
-      "integrity": "sha512-chvPX29ZBcMDuh7rLIgb0Cru6oJ/0FaqRzfOI3wT4W2F9W1HOlCtipovzmPYaUAmXBWfVP4EBO9TOWnpog0S0w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.10.tgz",
+      "integrity": "sha512-0XTsPjNflFhOl2CfNEdGeDOklG2t+m/D3g10Y7hg9dBjC1dURUEqTmM4d6J7JNbBURrP+/iP7uLsn3WRSipGUw==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.9.tgz",
-      "integrity": "sha512-9Je7+Jmx0AOyRzBBumraVJG3M0R6YbT4c9jTUbLGJCcPxwDI3/u2ZzvW3rBqpmrDaqLxN5f1LcZeTZx287QeqQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.10.tgz",
+      "integrity": "sha512-TOZiK7ji550F8G39Ri255NnK1+2Xlr74RiElJdQct4TzfN0lqNf2KRDFFNwDohkP/78FUzcP4qBxs+Nf8M7OuQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -990,9 +990,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.2.9",
-        "@angular/common": "16.2.9",
-        "@angular/core": "16.2.9"
+        "@angular/animations": "16.2.10",
+        "@angular/common": "16.2.10",
+        "@angular/core": "16.2.10"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.9.tgz",
-      "integrity": "sha512-ztpo0939vTZ/5CWVSvo41Yl6YPoTZ0If+yTrs7dk1ce0vFgaZXMlc+y5ZwjJIiMM5CvHbhL48Uk+HJNIojP98A==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.10.tgz",
+      "integrity": "sha512-YVmhAjOmsp2SWRonv6Mr/qXuKroCiew9asd1IlAZ//wqcml9ZrNAcX3WlDa8ZqdmOplQb0LuvvirfNB/6Is/jg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1012,10 +1012,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.2.9",
-        "@angular/compiler": "16.2.9",
-        "@angular/core": "16.2.9",
-        "@angular/platform-browser": "16.2.9"
+        "@angular/common": "16.2.10",
+        "@angular/compiler": "16.2.10",
+        "@angular/core": "16.2.10",
+        "@angular/platform-browser": "16.2.10"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -1047,26 +1047,26 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
-      "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
+      "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.5",
-        "@babel/helper-module-transforms": "^7.22.5",
-        "@babel/helpers": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
-        "@babel/types": "^7.22.5",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helpers": "^7.23.2",
+        "@babel/parser": "^7.23.0",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1076,10 +1076,46 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
+    "node_modules/@babel/core/node_modules/@babel/generator": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dev": true,
-      "license": "ISC",
+      "dependencies": {
+        "@babel/types": "^7.23.0",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/template": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1124,13 +1160,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-      "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.15",
         "browserslist": "^4.21.9",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -1298,28 +1334,28 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-      "integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-simple-access": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.5"
+        "@babel/helper-validator-identifier": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1438,9 +1474,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -1461,14 +1497,28 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
-      "integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.10",
-        "@babel/types": "^7.22.10"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/template": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3542,9 +3592,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.6.tgz",
-      "integrity": "sha512-d8ZlZL6dOtWmHdjG9PTGBkdiJMcsXD2tp6WeFRVvTEuvCI3XvKsUXBvJDE+mZOhzn5pUEYt+1TR5DHjDZbME3w==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.7.tgz",
+      "integrity": "sha512-QnVoYpMNMuV387VgmP/c/ylD9qUIZpN02LMg3rQqz7NDej0jboBZaxqLJ+7jQaCoEIFVGIgL/RR/X1kponxJZg==",
       "dev": true,
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -4095,13 +4145,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.6.tgz",
-      "integrity": "sha512-fM09WPqST+nhVGV5Q3fhG7WKo96kgSVMsbz3wGS0DmTn4zge7ZWnrW3VvbxnMapmGoKa9DFPqdqNln4ADcdIMQ==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.7.tgz",
+      "integrity": "sha512-sL+7vmwYPdo29rp99XYlm8gibqcjjOL5LKEleVQlv63SRES3HLMt7DeYivUfizcMENu/1hDtX41ig4Mu1SpNzg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.6",
-        "@angular-devkit/schematics": "16.2.6",
+        "@angular-devkit/core": "16.2.7",
+        "@angular-devkit/schematics": "16.2.7",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -4201,9 +4251,9 @@
       }
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
-      "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.4.tgz",
+      "integrity": "sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==",
       "dev": true,
       "dependencies": {
         "@types/connect": "*",
@@ -4211,27 +4261,27 @@
       }
     },
     "node_modules/@types/bonjour": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.11.tgz",
-      "integrity": "sha512-isGhjmBtLIxdHBDl2xGwUzEM8AOyOvWsADWq7rqirdi/ZQoHnLWErHvsThcEzTX8juDRiZtzp2Qkv5bgNh6mAg==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.12.tgz",
+      "integrity": "sha512-ky0kWSqXVxSqgqJvPIkgFkcn4C8MnRog308Ou8xBBIVo39OmUFy+jqNe0nPwLCDFxUpmT9EvT91YzOJgkDRcFg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
-      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
+      "version": "3.4.37",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.37.tgz",
+      "integrity": "sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/connect-history-api-fallback": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.1.tgz",
-      "integrity": "sha512-iaQslNbARe8fctL5Lk+DsmgWOM83lM+7FzP0eQUJs1jd3kBE8NWqBTIT2S8SqQOJjxvt2eyIjpOuYeRXq2AdMw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.2.tgz",
+      "integrity": "sha512-gX2j9x+NzSh4zOhnRPSdPPmTepS4DfxES0AvIFv3jGv5QyeAJf6u6dY5/BAoAJU9Qq1uTvwOku8SSC2GnCRl6Q==",
       "dev": true,
       "dependencies": {
         "@types/express-serve-static-core": "*",
@@ -4278,9 +4328,9 @@
       "dev": true
     },
     "node_modules/@types/express": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.19.tgz",
-      "integrity": "sha512-UtOfBtzN9OvpZPPbnnYunfjM7XCI4jyk1NvnFhTVz5krYAnW4o5DCoIekvms+8ApqhB4+9wSge1kBijdfTSmfg==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.20.tgz",
+      "integrity": "sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==",
       "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
@@ -4290,9 +4340,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.37",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
-      "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
+      "version": "4.17.39",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
+      "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -4302,15 +4352,15 @@
       }
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz",
-      "integrity": "sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.3.tgz",
+      "integrity": "sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA==",
       "dev": true
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.12",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.12.tgz",
-      "integrity": "sha512-kQtujO08dVtQ2wXAuSFfk9ASy3sug4+ogFR8Kd8UgP8PEuc1/G/8yjYRmp//PcDNJEUKOza/MrQu15bouEUCiw==",
+      "version": "1.17.13",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.13.tgz",
+      "integrity": "sha512-GkhdWcMNiR5QSQRYnJ+/oXzu0+7JJEPC8vkWXK351BkhjraZF+1W13CUYARUvX9+NqIU2n6YHA4iwywsc/M6Sw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -4338,9 +4388,9 @@
       "dev": true
     },
     "node_modules/@types/mime": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
-      "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw==",
       "dev": true
     },
     "node_modules/@types/minimist": {
@@ -4370,15 +4420,15 @@
       "peer": true
     },
     "node_modules/@types/qs": {
-      "version": "6.9.8",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
-      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
+      "version": "6.9.9",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.9.tgz",
+      "integrity": "sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
-      "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.6.tgz",
+      "integrity": "sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -4407,9 +4457,9 @@
       "dev": true
     },
     "node_modules/@types/send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.3.tgz",
+      "integrity": "sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==",
       "dev": true,
       "dependencies": {
         "@types/mime": "^1",
@@ -4417,18 +4467,18 @@
       }
     },
     "node_modules/@types/serve-index": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.2.tgz",
-      "integrity": "sha512-asaEIoc6J+DbBKXtO7p2shWUpKacZOoMBEGBgPG91P8xhO53ohzHWGCs4ScZo5pQMf5ukQzVT9fhX1WzpHihig==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.3.tgz",
+      "integrity": "sha512-4KG+yMEuvDPRrYq5fyVm/I2uqAJSAwZK9VSa+Zf+zUq9/oxSSvy3kkIqyL+jjStv6UCVi8/Aho0NHtB1Fwosrg==",
       "dev": true,
       "dependencies": {
         "@types/express": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz",
-      "integrity": "sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.4.tgz",
+      "integrity": "sha512-aqqNfs1XTF0HDrFdlY//+SGUxmdSUbjeRXb5iaZc3x0/vMbYmdw9qvOgHWOyyLFxSSRnUuP5+724zBgfw8/WAw==",
       "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
@@ -4437,18 +4487,18 @@
       }
     },
     "node_modules/@types/sockjs": {
-      "version": "0.3.34",
-      "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.34.tgz",
-      "integrity": "sha512-R+n7qBFnm/6jinlteC9DBL5dGiDGjWAvjo4viUanpnc/dG1y7uDoacXPIQ/PQEg1fI912SMHIa014ZjRpvDw4g==",
+      "version": "0.3.35",
+      "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.35.tgz",
+      "integrity": "sha512-tIF57KB+ZvOBpAQwSaACfEu7htponHXaFzP7RfKYgsOS0NoYnn+9+jzp7bbq4fWerizI3dTB4NfAZoyeQKWJLw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.7.tgz",
-      "integrity": "sha512-6UrLjiDUvn40CMrAubXuIVtj2PEfKDffJS7ychvnPU44j+KVeXmdHHTgqcM/dxLUTHxlXHiFM8Skmb8ozGdTnQ==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -11606,9 +11656,9 @@
       "license": "ISC"
     },
     "node_modules/json5": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
-      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.2.9"
+    "@angular/core": "^16.2.10"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.2.6",
+    "@angular-devkit/build-angular": "^16.2.7",
     "@angular-eslint/builder": "^16.2.0",
     "@angular-eslint/eslint-plugin": "^16.2.0",
     "@angular-eslint/eslint-plugin-template": "^16.2.0",
     "@angular-eslint/schematics": "^16.2.0",
     "@angular-eslint/template-parser": "^16.2.0",
-    "@angular/cli": "^16.2.6",
-    "@angular/common": "^16.2.9",
-    "@angular/compiler": "^16.2.9",
-    "@angular/compiler-cli": "^16.2.9",
-    "@angular/platform-browser": "^16.2.9",
-    "@angular/platform-browser-dynamic": "^16.2.9",
+    "@angular/cli": "^16.2.7",
+    "@angular/common": "^16.2.10",
+    "@angular/compiler": "^16.2.10",
+    "@angular/compiler-cli": "^16.2.10",
+    "@angular/platform-browser": "^16.2.10",
+    "@angular/platform-browser-dynamic": "^16.2.10",
     "@types/jasmine": "^5.1.1",
     "@types/jasminewd2": "~2.0.12",
     "@types/node": "^20.8.7",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            16.2.6 -> 16.2.7         ng update @angular/cli
      @angular/core                           16.2.9 -> 16.2.10        ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>