### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^16.2.7",
+        "@angular-devkit/build-angular": "^16.2.8",
         "@angular-eslint/builder": "^16.2.0",
         "@angular-eslint/eslint-plugin": "^16.2.0",
         "@angular-eslint/eslint-plugin-template": "^16.2.0",
         "@angular-eslint/schematics": "^16.2.0",
         "@angular-eslint/template-parser": "^16.2.0",
-        "@angular/cli": "^16.2.7",
-        "@angular/common": "^16.2.10",
-        "@angular/compiler": "^16.2.10",
-        "@angular/compiler-cli": "^16.2.10",
-        "@angular/platform-browser": "^16.2.10",
-        "@angular/platform-browser-dynamic": "^16.2.10",
+        "@angular/cli": "^16.2.8",
+        "@angular/common": "^16.2.11",
+        "@angular/compiler": "^16.2.11",
+        "@angular/compiler-cli": "^16.2.11",
+        "@angular/platform-browser": "^16.2.11",
+        "@angular/platform-browser-dynamic": "^16.2.11",
         "@types/jasmine": "^5.1.1",
         "@types/jasminewd2": "~2.0.12",
         "@types/node": "^20.8.9",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.3"
       },
       "peerDependencies": {
-        "@angular/core": "^16.2.10"
+        "@angular/core": "^16.2.11"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1602.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.7.tgz",
-      "integrity": "sha512-r6+z4jRE+e9VNeTmJCGz5VI5azRagOqE4SIDqaywz75eHOJ9UPSo9MHy8zFw1eLt1WcvCDqk+Pk9+krh2E+B8Q==",
+      "version": "0.1602.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.8.tgz",
+      "integrity": "sha512-bNdu2tF29Y/jOxMXlu9pmNbIlyZs9hRjLmi/tcfcMFay+3AhpNO59DWlUmI4gpvWu8CEXdQHSMuJTDHaNR+Ctg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.7",
+        "@angular-devkit/core": "16.2.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.7.tgz",
-      "integrity": "sha512-OTH4qzXmWXifhvH0iXwPUhElWEU9SUcIZyWYbv2NR5ImAw/GE07vDuBljGRJeSEC9MpFbThwEFbHD8oRWiLUag==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.8.tgz",
+      "integrity": "sha512-PgTaWerhDO3JjHjgJl/VWB1y1awN8eHrm7sqdpIsgKbVpi26oyByjtPS1gKKhinps9Che66lCbnxrkx2X3rWTg==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1602.7",
-        "@angular-devkit/build-webpack": "0.1602.7",
-        "@angular-devkit/core": "16.2.7",
+        "@angular-devkit/architect": "0.1602.8",
+        "@angular-devkit/build-webpack": "0.1602.8",
+        "@angular-devkit/core": "16.2.8",
         "@babel/core": "7.22.9",
         "@babel/generator": "7.22.9",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -109,7 +109,7 @@
         "@babel/runtime": "7.22.6",
         "@babel/template": "7.22.5",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "16.2.7",
+        "@ngtools/webpack": "16.2.8",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.14",
@@ -655,12 +655,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1602.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.7.tgz",
-      "integrity": "sha512-3+MV9ehn65XUUMSBBgfg5K2zZs2jhif75ypI+BBUfZDUWeKR5MeGJy0aDHZ+2H94kPkmSD3PrkOuitWdnDjTgA==",
+      "version": "0.1602.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.8.tgz",
+      "integrity": "sha512-wGE2R6hnhSVpH7jvqtkZ63IX9oMRd+uh7sC65hGgzajPqThQcNdnGG3+79QGWapgkoHuZHpDlKOBFt0IOMAaMA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.7",
+        "@angular-devkit/architect": "0.1602.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.7.tgz",
-      "integrity": "sha512-XskObYrg7NRdEuHnSVZOM7OeinEL8HzugjmKnawAa+dAbFCCoGsVWjMliA/Q8sb1yfGkyL0WW7DZABZj7EGwWA==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.8.tgz",
+      "integrity": "sha512-PTGozYvh1Bin5lB15PwcXa26Ayd17bWGLS3H8Rs0s+04mUDvfNofmweaX1LgumWWy3nCUTDuwHxX10M3G0wE2g==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -701,12 +701,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.7.tgz",
-      "integrity": "sha512-zu3xHwA4w+kXHkyyjGl3i7uSU2/kKLPKuyyixw0WLcKUQCYd7TWmu8OC0qCDa42XkxP9gGL091dJFu56exgneA==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.8.tgz",
+      "integrity": "sha512-MBiKZOlR9/YMdflALr7/7w/BGAfo/BGTrlkqsIB6rDWV1dYiCgxI+033HsiNssLS6RQyCFx/e7JA2aBBzu9zEg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.7",
+        "@angular-devkit/core": "16.2.8",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.1",
         "ora": "5.4.1",
@@ -850,15 +850,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.7.tgz",
-      "integrity": "sha512-30yBAYzbrj/WM4tLiX4IU5byw0b5Y5LEzcpjYZglv/RXPrnevGlRXmgCulpt8wIdkd668N7kXEQ23nipuJDXMg==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.8.tgz",
+      "integrity": "sha512-iPrDv+SemRb6ZhayxwLsEdykHpV2TYSgH5Smg8GqSaIR/KUiemuzBrIKEUEaIG4n2dVEOtcsuh2JRHQndF7wmw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.7",
-        "@angular-devkit/core": "16.2.7",
-        "@angular-devkit/schematics": "16.2.7",
-        "@schematics/angular": "16.2.7",
+        "@angular-devkit/architect": "0.1602.8",
+        "@angular-devkit/core": "16.2.8",
+        "@angular-devkit/schematics": "16.2.8",
+        "@schematics/angular": "16.2.8",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.10.tgz",
-      "integrity": "sha512-cLth66aboInNcWFjDBRmK30jC5KN10nKDDcv4U/r3TDTBpKOtnmTjNFFr7dmjfUmVhHFy/66piBMfpjZI93Rxg==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.11.tgz",
+      "integrity": "sha512-h80WUR2OYlqxQy+4XgNtWT2vB+vZ6oCrFX/q8cU5jAvbvGQfJuH0zfcbSlUflStmAhk5/OT25F0mt96cqapEAw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -910,14 +910,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.10",
+        "@angular/core": "16.2.11",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.10.tgz",
-      "integrity": "sha512-ty6SfqkZlV2bLU/SSi3wmxrEFgPrK+WVslCNIr3FlTnCBdqpIbadHN2QB3A1d9XaNc7c4Tq5DQKh34cwMwNbuw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.11.tgz",
+      "integrity": "sha512-9q/E3uurvoQbdTTWDyWCLpzmfJ4+et7SUca1/EljD/X7Xg2FNU5GpTMutBtWFL7wDyWk1oswivuq9/C4GVW7fA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -926,7 +926,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.10"
+        "@angular/core": "16.2.11"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.10.tgz",
-      "integrity": "sha512-swgmtm4R23vQV9nJTXdDEFpOyIw3kz80mdT9qo3VId/2rqenOK253JsFypoqEj/fKzjV9gwXtTbmrMlhVyuyxw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.11.tgz",
+      "integrity": "sha512-ZtZCXfkVBH78HUm2Byf+WX3Y6WzQK9EXYXNU/ni1rvSZ1vLNwieLDfWb/xwiO7QojrHZTym1RJ10jTMinTguqw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -958,14 +958,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.2.10",
+        "@angular/compiler": "16.2.11",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.10.tgz",
-      "integrity": "sha512-0XTsPjNflFhOl2CfNEdGeDOklG2t+m/D3g10Y7hg9dBjC1dURUEqTmM4d6J7JNbBURrP+/iP7uLsn3WRSipGUw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.11.tgz",
+      "integrity": "sha512-Jb+7/p1vczQRQ3iC1QxUS5cE4X1hPVAvbrFnyMpSx6Pq5o274v/lK6PvhUZrfKrp9FxFp9pN+WHjUqNFqOuJZg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.10.tgz",
-      "integrity": "sha512-TOZiK7ji550F8G39Ri255NnK1+2Xlr74RiElJdQct4TzfN0lqNf2KRDFFNwDohkP/78FUzcP4qBxs+Nf8M7OuQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.11.tgz",
+      "integrity": "sha512-gUptbI3lbaRg+L8rcTlxKtFunYmR/M/mm9/l9uRd+5qk2mnFI0+s/tzRoaq7K0XaRGKZiWLNTz6FTkviO1zo2g==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -990,9 +990,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.2.10",
-        "@angular/common": "16.2.10",
-        "@angular/core": "16.2.10"
+        "@angular/animations": "16.2.11",
+        "@angular/common": "16.2.11",
+        "@angular/core": "16.2.11"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.10.tgz",
-      "integrity": "sha512-YVmhAjOmsp2SWRonv6Mr/qXuKroCiew9asd1IlAZ//wqcml9ZrNAcX3WlDa8ZqdmOplQb0LuvvirfNB/6Is/jg==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.11.tgz",
+      "integrity": "sha512-e+A7z6MUJaqC4Fdq7XQfIhAox3ZPM1lczM6G08fUKPbFDEe+c9i7C8YRLL+69BXDuG790btugIeOQcn5lnJcFg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1012,10 +1012,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.2.10",
-        "@angular/compiler": "16.2.10",
-        "@angular/core": "16.2.10",
-        "@angular/platform-browser": "16.2.10"
+        "@angular/common": "16.2.11",
+        "@angular/compiler": "16.2.11",
+        "@angular/core": "16.2.11",
+        "@angular/platform-browser": "16.2.11"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3592,9 +3592,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.7.tgz",
-      "integrity": "sha512-QnVoYpMNMuV387VgmP/c/ylD9qUIZpN02LMg3rQqz7NDej0jboBZaxqLJ+7jQaCoEIFVGIgL/RR/X1kponxJZg==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.8.tgz",
+      "integrity": "sha512-GeblhLBwXe3qPYa4YHxbo0xujRl1FKkfIusU1mTIhkQBRtZY4Xgz4iMnPIEMJTU3XXGMkS+SCx34lqbwwMhR5A==",
       "dev": true,
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -4104,13 +4104,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.7.tgz",
-      "integrity": "sha512-sL+7vmwYPdo29rp99XYlm8gibqcjjOL5LKEleVQlv63SRES3HLMt7DeYivUfizcMENu/1hDtX41ig4Mu1SpNzg==",
+      "version": "16.2.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.8.tgz",
+      "integrity": "sha512-yxfxJ2IMRIt+dQcqyJR30qd/osb5NwRsi9US3gFIHP1jfjOAs1Nk8ENNd5ycYV+yykCa78KWhmbOw4G1zpR56Q==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.7",
-        "@angular-devkit/schematics": "16.2.7",
+        "@angular-devkit/core": "16.2.8",
+        "@angular-devkit/schematics": "16.2.8",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -4364,6 +4364,15 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.8.tgz",
+      "integrity": "sha512-vGXshY9vim9CJjrpcS5raqSjEfKlJcWy2HNdgUasR66fAnVEYarrf1ULV4nfvpC1nZq/moA9qyqBcu83x+Jlrg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -16281,11 +16290,12 @@
       }
     },
     "node_modules/selfsigned": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
-      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
       "dev": true,
       "dependencies": {
+        "@types/node-forge": "^1.3.0",
         "node-forge": "^1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.2.10"
+    "@angular/core": "^16.2.11"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.2.7",
+    "@angular-devkit/build-angular": "^16.2.8",
     "@angular-eslint/builder": "^16.2.0",
     "@angular-eslint/eslint-plugin": "^16.2.0",
     "@angular-eslint/eslint-plugin-template": "^16.2.0",
     "@angular-eslint/schematics": "^16.2.0",
     "@angular-eslint/template-parser": "^16.2.0",
-    "@angular/cli": "^16.2.7",
-    "@angular/common": "^16.2.10",
-    "@angular/compiler": "^16.2.10",
-    "@angular/compiler-cli": "^16.2.10",
-    "@angular/platform-browser": "^16.2.10",
-    "@angular/platform-browser-dynamic": "^16.2.10",
+    "@angular/cli": "^16.2.8",
+    "@angular/common": "^16.2.11",
+    "@angular/compiler": "^16.2.11",
+    "@angular/compiler-cli": "^16.2.11",
+    "@angular/platform-browser": "^16.2.11",
+    "@angular/platform-browser-dynamic": "^16.2.11",
     "@types/jasmine": "^5.1.1",
     "@types/jasminewd2": "~2.0.12",
     "@types/node": "^20.8.9",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            16.2.7 -> 16.2.8         ng update @angular/cli
      @angular/core                           16.2.10 -> 16.2.11       ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>