### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^16.2.8",
+        "@angular-devkit/build-angular": "^16.2.9",
         "@angular-eslint/builder": "^16.2.0",
         "@angular-eslint/eslint-plugin": "^16.2.0",
         "@angular-eslint/eslint-plugin-template": "^16.2.0",
         "@angular-eslint/schematics": "^16.2.0",
         "@angular-eslint/template-parser": "^16.2.0",
-        "@angular/cli": "^16.2.8",
-        "@angular/common": "^16.2.11",
-        "@angular/compiler": "^16.2.11",
-        "@angular/compiler-cli": "^16.2.11",
-        "@angular/platform-browser": "^16.2.11",
-        "@angular/platform-browser-dynamic": "^16.2.11",
+        "@angular/cli": "^16.2.9",
+        "@angular/common": "^16.2.12",
+        "@angular/compiler": "^16.2.12",
+        "@angular/compiler-cli": "^16.2.12",
+        "@angular/platform-browser": "^16.2.12",
+        "@angular/platform-browser-dynamic": "^16.2.12",
         "@types/jasmine": "^5.1.1",
         "@types/jasminewd2": "~2.0.12",
         "@types/node": "^20.8.10",
@@ -48,7 +48,7 @@
         "zone.js": "^0.13.3"
       },
       "peerDependencies": {
-        "@angular/core": "^16.2.11"
+        "@angular/core": "^16.2.12"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1602.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.8.tgz",
-      "integrity": "sha512-bNdu2tF29Y/jOxMXlu9pmNbIlyZs9hRjLmi/tcfcMFay+3AhpNO59DWlUmI4gpvWu8CEXdQHSMuJTDHaNR+Ctg==",
+      "version": "0.1602.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.9.tgz",
+      "integrity": "sha512-U3vfb/e2sFfg0D9FyyRBXRPP7g4FBFtGK8Q3JPmvAVsHHwi5AUFRNR7YBChB/T5TMNY077HcTyEirVh2FeUpdA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.8",
+        "@angular-devkit/core": "16.2.9",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.8.tgz",
-      "integrity": "sha512-PgTaWerhDO3JjHjgJl/VWB1y1awN8eHrm7sqdpIsgKbVpi26oyByjtPS1gKKhinps9Che66lCbnxrkx2X3rWTg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.9.tgz",
+      "integrity": "sha512-S1C4UYxRVyNt3C0wCxbT2jZ1dN5i37kS0mol3PQjbR8gQ0GQzHmzhjTBl1oImo8aouET9yhrk9etk65oat4mBQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1602.8",
-        "@angular-devkit/build-webpack": "0.1602.8",
-        "@angular-devkit/core": "16.2.8",
+        "@angular-devkit/architect": "0.1602.9",
+        "@angular-devkit/build-webpack": "0.1602.9",
+        "@angular-devkit/core": "16.2.9",
         "@babel/core": "7.22.9",
         "@babel/generator": "7.22.9",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -109,7 +109,7 @@
         "@babel/runtime": "7.22.6",
         "@babel/template": "7.22.5",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "16.2.8",
+        "@ngtools/webpack": "16.2.9",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.14",
@@ -655,12 +655,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1602.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.8.tgz",
-      "integrity": "sha512-wGE2R6hnhSVpH7jvqtkZ63IX9oMRd+uh7sC65hGgzajPqThQcNdnGG3+79QGWapgkoHuZHpDlKOBFt0IOMAaMA==",
+      "version": "0.1602.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.9.tgz",
+      "integrity": "sha512-+3IxovfBPR2Vy730mGa0SVKkd5LQVom85gjXOs7WcnnnZmfc1q/BtFlqTgW1UWvTxP8IQdm7UYWVclQfL/WExw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.8",
+        "@angular-devkit/architect": "0.1602.9",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.8.tgz",
-      "integrity": "sha512-PTGozYvh1Bin5lB15PwcXa26Ayd17bWGLS3H8Rs0s+04mUDvfNofmweaX1LgumWWy3nCUTDuwHxX10M3G0wE2g==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.9.tgz",
+      "integrity": "sha512-dcHWjHBNGm3yCeNz19y8A1At4KgyC6XHNnbFL0y+nnZYiaESXjUoXJYKASedI6A+Bpl0HNq2URhH6bL6Af3+4w==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -701,12 +701,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.8.tgz",
-      "integrity": "sha512-MBiKZOlR9/YMdflALr7/7w/BGAfo/BGTrlkqsIB6rDWV1dYiCgxI+033HsiNssLS6RQyCFx/e7JA2aBBzu9zEg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.9.tgz",
+      "integrity": "sha512-lB51CGCILpcSI37CwKUAGDLxMqh7zmuRbiPo9s9mSkCM4ccqxFlaL+VFTq2/laneARD6aikpOHnkVm5myNzQPw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.8",
+        "@angular-devkit/core": "16.2.9",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.1",
         "ora": "5.4.1",
@@ -850,15 +850,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.8.tgz",
-      "integrity": "sha512-iPrDv+SemRb6ZhayxwLsEdykHpV2TYSgH5Smg8GqSaIR/KUiemuzBrIKEUEaIG4n2dVEOtcsuh2JRHQndF7wmw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.9.tgz",
+      "integrity": "sha512-wkpV/Ni26LUeDmhee2TPXXEq3feEdZMSG8+nkfUK9kqIcxm0IjI1GLPeiVOX7aQobuKNe2cCAFNwsrXWjj+2og==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.8",
-        "@angular-devkit/core": "16.2.8",
-        "@angular-devkit/schematics": "16.2.8",
-        "@schematics/angular": "16.2.8",
+        "@angular-devkit/architect": "0.1602.9",
+        "@angular-devkit/core": "16.2.9",
+        "@angular-devkit/schematics": "16.2.9",
+        "@schematics/angular": "16.2.9",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.11.tgz",
-      "integrity": "sha512-h80WUR2OYlqxQy+4XgNtWT2vB+vZ6oCrFX/q8cU5jAvbvGQfJuH0zfcbSlUflStmAhk5/OT25F0mt96cqapEAw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.12.tgz",
+      "integrity": "sha512-B+WY/cT2VgEaz9HfJitBmgdk4I333XG/ybC98CMC4Wz8E49T8yzivmmxXB3OD6qvjcOB6ftuicl6WBqLbZNg2w==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -910,14 +910,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.11",
+        "@angular/core": "16.2.12",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.11.tgz",
-      "integrity": "sha512-9q/E3uurvoQbdTTWDyWCLpzmfJ4+et7SUca1/EljD/X7Xg2FNU5GpTMutBtWFL7wDyWk1oswivuq9/C4GVW7fA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.12.tgz",
+      "integrity": "sha512-6SMXUgSVekGM7R6l1Z9rCtUGtlg58GFmgbpMCsGf+VXxP468Njw8rjT2YZkf5aEPxEuRpSHhDYjqz7n14cwCXQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -926,7 +926,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.2.11"
+        "@angular/core": "16.2.12"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.11.tgz",
-      "integrity": "sha512-ZtZCXfkVBH78HUm2Byf+WX3Y6WzQK9EXYXNU/ni1rvSZ1vLNwieLDfWb/xwiO7QojrHZTym1RJ10jTMinTguqw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.12.tgz",
+      "integrity": "sha512-pWSrr152562ujh6lsFZR8NfNc5Ljj+zSTQO44DsuB0tZjwEpnRcjJEgzuhGXr+CoiBf+jTSPZKemtSktDk5aaA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -958,14 +958,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.2.11",
+        "@angular/compiler": "16.2.12",
         "typescript": ">=4.9.3 <5.2"
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.11.tgz",
-      "integrity": "sha512-Jb+7/p1vczQRQ3iC1QxUS5cE4X1hPVAvbrFnyMpSx6Pq5o274v/lK6PvhUZrfKrp9FxFp9pN+WHjUqNFqOuJZg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.12.tgz",
+      "integrity": "sha512-GLLlDeke/NjroaLYOks0uyzFVo6HyLl7VOm0K1QpLXnYvW63W9Ql/T3yguRZa7tRkOAeFZ3jw+1wnBD4O8MoUA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.11.tgz",
-      "integrity": "sha512-gUptbI3lbaRg+L8rcTlxKtFunYmR/M/mm9/l9uRd+5qk2mnFI0+s/tzRoaq7K0XaRGKZiWLNTz6FTkviO1zo2g==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.12.tgz",
+      "integrity": "sha512-NnH7ju1iirmVEsUq432DTm0nZBGQsBrU40M3ZeVHMQ2subnGiyUs3QyzDz8+VWLL/T5xTxWLt9BkDn65vgzlIQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -990,9 +990,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.2.11",
-        "@angular/common": "16.2.11",
-        "@angular/core": "16.2.11"
+        "@angular/animations": "16.2.12",
+        "@angular/common": "16.2.12",
+        "@angular/core": "16.2.12"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.11.tgz",
-      "integrity": "sha512-e+A7z6MUJaqC4Fdq7XQfIhAox3ZPM1lczM6G08fUKPbFDEe+c9i7C8YRLL+69BXDuG790btugIeOQcn5lnJcFg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.12.tgz",
+      "integrity": "sha512-ya54jerNgreCVAR278wZavwjrUWImMr2F8yM5n9HBvsMBbFaAQ83anwbOEiHEF2BlR+gJiEBLfpuPRMw20pHqw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1012,10 +1012,10 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.2.11",
-        "@angular/compiler": "16.2.11",
-        "@angular/core": "16.2.11",
-        "@angular/platform-browser": "16.2.11"
+        "@angular/common": "16.2.12",
+        "@angular/compiler": "16.2.12",
+        "@angular/core": "16.2.12",
+        "@angular/platform-browser": "16.2.12"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3592,9 +3592,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.8.tgz",
-      "integrity": "sha512-GeblhLBwXe3qPYa4YHxbo0xujRl1FKkfIusU1mTIhkQBRtZY4Xgz4iMnPIEMJTU3XXGMkS+SCx34lqbwwMhR5A==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.9.tgz",
+      "integrity": "sha512-rOclD7FfT4OSwVA0nDnULbJS6TORJ0+sQiuT2ebaNFErYr3LOm6Zut05tnmzFw8q1cePrILbG+xpnbggNr9Pyw==",
       "dev": true,
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -4104,13 +4104,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.8.tgz",
-      "integrity": "sha512-yxfxJ2IMRIt+dQcqyJR30qd/osb5NwRsi9US3gFIHP1jfjOAs1Nk8ENNd5ycYV+yykCa78KWhmbOw4G1zpR56Q==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.9.tgz",
+      "integrity": "sha512-uiU2YbZRVHgk1N1DDsek/5CKhfpZ8myJYNJk8eHV5LswnXOP3aqvH23VhneaAgOYwK5fISC7eMG0pLVKMvFfZQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.8",
-        "@angular-devkit/schematics": "16.2.8",
+        "@angular-devkit/core": "16.2.9",
+        "@angular-devkit/schematics": "16.2.9",
         "jsonc-parser": "3.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^16.2.11"
+    "@angular/core": "^16.2.12"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.2.8",
+    "@angular-devkit/build-angular": "^16.2.9",
     "@angular-eslint/builder": "^16.2.0",
     "@angular-eslint/eslint-plugin": "^16.2.0",
     "@angular-eslint/eslint-plugin-template": "^16.2.0",
     "@angular-eslint/schematics": "^16.2.0",
     "@angular-eslint/template-parser": "^16.2.0",
-    "@angular/cli": "^16.2.8",
-    "@angular/common": "^16.2.11",
-    "@angular/compiler": "^16.2.11",
-    "@angular/compiler-cli": "^16.2.11",
-    "@angular/platform-browser": "^16.2.11",
-    "@angular/platform-browser-dynamic": "^16.2.11",
+    "@angular/cli": "^16.2.9",
+    "@angular/common": "^16.2.12",
+    "@angular/compiler": "^16.2.12",
+    "@angular/compiler-cli": "^16.2.12",
+    "@angular/platform-browser": "^16.2.12",
+    "@angular/platform-browser-dynamic": "^16.2.12",
     "@types/jasmine": "^5.1.1",
     "@types/jasminewd2": "~2.0.12",
     "@types/node": "^20.8.10",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            16.2.8 -> 16.2.9         ng update @angular/cli
      @angular/core                           16.2.11 -> 16.2.12       ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>