### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "@angular-eslint/schematics": "^17.0.1",
         "@angular-eslint/template-parser": "^17.0.1",
         "@angular/cli": "^17.0.0",
-        "@angular/common": "^17.0.1",
-        "@angular/compiler": "^17.0.1",
-        "@angular/compiler-cli": "^17.0.1",
-        "@angular/platform-browser": "^17.0.1",
-        "@angular/platform-browser-dynamic": "^17.0.1",
+        "@angular/common": "^17.0.2",
+        "@angular/compiler": "^17.0.2",
+        "@angular/compiler-cli": "^17.0.2",
+        "@angular/platform-browser": "^17.0.2",
+        "@angular/platform-browser-dynamic": "^17.0.2",
         "@types/jasmine": "^5.1.2",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.9.0",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.2"
       },
       "peerDependencies": {
-        "@angular/core": "^17.0.1"
+        "@angular/core": "^17.0.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.1.tgz",
-      "integrity": "sha512-AvvhZc+PhX5lVEW/Vorxe3Zf1rIEJJvfduRuRv+nsjijo3ZGjdgYjTYEx4ighZgH60RLIAuwyBE24gPkT2Pm7g==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.2.tgz",
+      "integrity": "sha512-hCW0njHgrcwTWNoKZDwf02DnhYLVWNXM2FMw66MKpfxTp7McSyaXjGBU9/hchW3dZJ0xTwyxoyoqJFoHYvg0yg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -885,14 +885,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.1",
+        "@angular/core": "17.0.2",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.1.tgz",
-      "integrity": "sha512-qlKqCvjoxPHJ1e8+UMaBl/n9zzrmGXI5eWMVhULSvQnQvPWkwNlUh5XFeoSFcTEQxORjaO2/08Z31DmTJAqlPA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.2.tgz",
+      "integrity": "sha512-ewUFbKhMEhAmw2dGfk0ImhTlyrO2y4pJSKIZdFrkR1d0HiJX8bCHUdTiiR/2jeP7w2eamjXj15Rptb+iZZes2Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -901,7 +901,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.1"
+        "@angular/core": "17.0.2"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.1.tgz",
-      "integrity": "sha512-Rnvh2V2CYhG7NR5VI4cESGKk9jyqLat0HoqXa06v3TtbjkiZyjjwh0SyZ8NYOBMkQeWiQTHGcgxGvjKD3L3qqA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.2.tgz",
+      "integrity": "sha512-IUYL3Yz5RbR0Z0/x7it4GK3sMb2qVihxu0tlgfUW53P1Vi6nU/Zda0bCJTu6Z64qEtS8zwCwF1Ekomuq6UaiKg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -933,14 +933,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.0.1",
+        "@angular/compiler": "17.0.2",
         "typescript": ">=5.2 <5.3"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.1.tgz",
-      "integrity": "sha512-yVwU+oz0G8g6Q5ORyOCpgqMPdSiCdfW+uQhjI37WROnXHja3jY843AqrYTKE6mMx1r6q9h1wbDy+x2E61OWP7A==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.2.tgz",
+      "integrity": "sha512-MjDxWeyn3Txi0qo/V/I+B/gndh0uptQ0XWgBRwOx6Wcr5zRGeZIFlXBxPpyXnGTlJkeyErsTN7FfFCZ4C3kCPA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.1.tgz",
-      "integrity": "sha512-JpvU0YDEM5KYdHtxC0Kdzk/hdwvZPq5vju5lTmIjTVa2OOabApOrQ6cq1MpKlrvjv1rw8MClHIM0l5Y0g9KH5g==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.2.tgz",
+      "integrity": "sha512-eTnPILEA/eAMkVUR/+g6fWhhMTmnmOzcZSGX/bBgQcvOhayZrDDxA6/Qf+jIB4RwC0wd3KA9zT5BCMmNojoUsg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -965,9 +965,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.0.1",
-        "@angular/common": "17.0.1",
-        "@angular/core": "17.0.1"
+        "@angular/animations": "17.0.2",
+        "@angular/common": "17.0.2",
+        "@angular/core": "17.0.2"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.1.tgz",
-      "integrity": "sha512-xEcbB/ukXc65LaX4JBQYEM7D5Z8LcUIZniSJFneY7deZt3wNiKgmPZrPoXUyDV26QULh7N0IADEzvbcMF60AFQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.2.tgz",
+      "integrity": "sha512-clcHqHcfD00/TlTixDbJ3q4EQxpm0t2ZFG76rRFmGrmE5tKYUPfaofIa3hQCxy3q269MAYuF16wALhUtrEWyUA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -987,10 +987,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.0.1",
-        "@angular/compiler": "17.0.1",
-        "@angular/core": "17.0.1",
-        "@angular/platform-browser": "17.0.1"
+        "@angular/common": "17.0.2",
+        "@angular/compiler": "17.0.2",
+        "@angular/core": "17.0.2",
+        "@angular/platform-browser": "17.0.2"
       }
     },
     "node_modules/@assemblyscript/loader": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.0.1"
+    "@angular/core": "^17.0.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.0.0",
@@ -37,11 +37,11 @@
     "@angular-eslint/schematics": "^17.0.1",
     "@angular-eslint/template-parser": "^17.0.1",
     "@angular/cli": "^17.0.0",
-    "@angular/common": "^17.0.1",
-    "@angular/compiler": "^17.0.1",
-    "@angular/compiler-cli": "^17.0.1",
-    "@angular/platform-browser": "^17.0.1",
-    "@angular/platform-browser-dynamic": "^17.0.1",
+    "@angular/common": "^17.0.2",
+    "@angular/compiler": "^17.0.2",
+    "@angular/compiler-cli": "^17.0.2",
+    "@angular/platform-browser": "^17.0.2",
+    "@angular/platform-browser-dynamic": "^17.0.2",
     "@types/jasmine": "^5.1.2",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.9.0",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/core                           17.0.1 -> 17.0.2         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>