### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.0.1",
+        "@angular-devkit/build-angular": "^17.0.3",
         "@angular-eslint/builder": "^17.1.0",
         "@angular-eslint/eslint-plugin": "^17.1.0",
         "@angular-eslint/eslint-plugin-template": "^17.1.0",
         "@angular-eslint/schematics": "^17.1.0",
         "@angular-eslint/template-parser": "^17.1.0",
-        "@angular/cli": "^17.0.1",
-        "@angular/common": "^17.0.3",
-        "@angular/compiler": "^17.0.3",
-        "@angular/compiler-cli": "^17.0.3",
-        "@angular/platform-browser": "^17.0.3",
-        "@angular/platform-browser-dynamic": "^17.0.3",
+        "@angular/cli": "^17.0.3",
+        "@angular/common": "^17.0.4",
+        "@angular/compiler": "^17.0.4",
+        "@angular/compiler-cli": "^17.0.4",
+        "@angular/platform-browser": "^17.0.4",
+        "@angular/platform-browser-dynamic": "^17.0.4",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.9.5",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.2"
       },
       "peerDependencies": {
-        "@angular/core": "^17.0.3"
+        "@angular/core": "^17.0.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1700.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.1.tgz",
-      "integrity": "sha512-w84luzQNRjlt7XxX3+jyzcwBBv3gAjjvFWTjN1E5mlpDCUXgYmQ3CMowFHeu0U06HD5Sapap9p2l6GoajuZK5Q==",
+      "version": "0.1700.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.3.tgz",
+      "integrity": "sha512-HUjx7vD16paWXHKHYc2LsSn/kaYbFr2YNnlzuSr9C0kauKS1e7sRpRvtGwQzXfohzgyKi81AAU5uA2KLRGq83w==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.1",
+        "@angular-devkit/core": "17.0.3",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.1.tgz",
-      "integrity": "sha512-OomGAeBg/OOxzPpoU7EkdD3WwhKip+0Giy/cGtkalSgQ5vWTuZhf8UnxwTf7xEXW5LtvfoTtv7sKmb1dJT7FzA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.3.tgz",
+      "integrity": "sha512-1lx0mERC1eTHX4vf8q7kUHZNHS0jwZxbwYHAISOplwHjkzRociX0W6rx04yMXn2NCSNhK+w3xbWyAIgyYbP9nA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1700.1",
-        "@angular-devkit/build-webpack": "0.1700.1",
-        "@angular-devkit/core": "17.0.1",
+        "@angular-devkit/architect": "0.1700.3",
+        "@angular-devkit/build-webpack": "0.1700.3",
+        "@angular-devkit/core": "17.0.3",
         "@babel/core": "7.23.2",
         "@babel/generator": "7.23.0",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.23.2",
         "@babel/runtime": "7.23.2",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.0.1",
+        "@ngtools/webpack": "17.0.3",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.16",
@@ -629,12 +629,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1700.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.1.tgz",
-      "integrity": "sha512-u9LTcG9Kg2J6WkF1WSoBLdDabhbKxcuHY24SouAJTwg33j6YksglL7qnofOsNxny3Gdnze2BhCjQ1GS9Y8ovXw==",
+      "version": "0.1700.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.3.tgz",
+      "integrity": "sha512-r8nVakAnwV5Yy2AjWDpdcGUjHRQBcPljZDhX5tX2H7M3bxD6zG5owXDy8XmG64A7U1jd6D7dQv7zoW/tZwpYvw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.1",
+        "@angular-devkit/architect": "0.1700.3",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.1.tgz",
-      "integrity": "sha512-UjNx9fZW0oU7UaeoB0HblYz/Nm8MWtinAe39XkY+zjECLWqKAcHPotfYjucXiky1UlBUOScIKbwjMDdEY8xkuw==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.3.tgz",
+      "integrity": "sha512-SOngD3rKnwZWhhUV68AYlH8M3LRGvF69jnDrYKwtRy1ESqSH7tt+1vexGC290gKvqH7bNMgYv8f5BS1AASRfzw==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -687,12 +687,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.1.tgz",
-      "integrity": "sha512-bwgdGviRZC5X8Tl4QcjtIJAcC0p8yIhOyYVFrq4PWYvI+DfV9P6w3OFuoS6rwEoiIQR90+12iKBYMt1MfL/c0Q==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.3.tgz",
+      "integrity": "sha512-gNocyYuNJRd24+JSM5kpO7g9Vg4THcoH5It8nJmS3muelLHDzegvDzXB7iPBjVR8Lxts6sbifYdIkKencUc4vg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.1",
+        "@angular-devkit/core": "17.0.3",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.5",
         "ora": "5.4.1",
@@ -825,15 +825,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.1.tgz",
-      "integrity": "sha512-3iJWw+bpr/8y1ZY1m0wGfukffQVmD6DJUNubB297NCq1bJyUj+uwBuDnpIH+vidJvPBEEY+9XPJr0Jnd6+i7rg==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.3.tgz",
+      "integrity": "sha512-pRGXms87aEqmB4yPdcPI/VM7JegjDcBIeLadms0wrBkoyQiv+jL5LesxODhid6ujXZOj1xqMCYbCnX7HY+mLcQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.1",
-        "@angular-devkit/core": "17.0.1",
-        "@angular-devkit/schematics": "17.0.1",
-        "@schematics/angular": "17.0.1",
+        "@angular-devkit/architect": "0.1700.3",
+        "@angular-devkit/core": "17.0.3",
+        "@angular-devkit/schematics": "17.0.3",
+        "@schematics/angular": "17.0.3",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.3.tgz",
-      "integrity": "sha512-AD/d1n0hNisHDhIeBsW2ERZI9ChjiOuZ3IiGwcYKmlcOHTrZTJPAh/ZMgahv24rArlNVax7bT+Ik8+sJedGcEQ==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.4.tgz",
+      "integrity": "sha512-/y38PbuiaWOuOmP5ZELTlJSjZGijc6Nq2XQloT5pKsaH935prxPjyWazwlY6cUnJMQgSRU644/ULosDJec7Zxw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -885,14 +885,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.3",
+        "@angular/core": "17.0.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.3.tgz",
-      "integrity": "sha512-ryUcj8Vc+Q4jMrjrmsEIsGLXeWSmNE/KoTyURPCH+NWq9GBMbjv4oe0/oFSBMN2ZtRMVCvqv2Nq+Z2KRDRGB0A==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.4.tgz",
+      "integrity": "sha512-OweJui9EWCa1ZcZjkJHS5z1gqICqyryR1Gdmyr8vIa6HD8wU/5BaeBJPCDgYgt+qJkvcT/sPxgZQsc2pVeUwbQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -901,7 +901,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.3"
+        "@angular/core": "17.0.4"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.3.tgz",
-      "integrity": "sha512-oj7KJBFgs6ulT1/A/xkkDHBOB0c7o9HV2Mn5pUosXBo2VgcGYeuJeXffC+mFr5FyiRO1sUanw4vSWnLzK1U0pQ==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.4.tgz",
+      "integrity": "sha512-ywj8XNI+hvHHYGcNWvXaVHSRtcd3S7MqJNgXWfnb0JjAb282oGSvjEc7wnH4ERqkvnSrpk1kQ2Fj3uJ2P5zfmQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -933,14 +933,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.0.3",
+        "@angular/compiler": "17.0.4",
         "typescript": ">=5.2 <5.3"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.3.tgz",
-      "integrity": "sha512-zY4yhPiphuktrodaM+GiP8G07qnUlmwKElLjYazeIR8A+kF51RQRpSf/pWe5M0uJIn5Oja+RdO9kzhDI9QvOcA==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.4.tgz",
+      "integrity": "sha512-zk+z5sYPZd87pLxECx27quB5FvSmoi9PjJlcSlaBwwqaGnh/tPJI14u3q1dRY/CoZgP9egEiwc428+DzvOzJew==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.3.tgz",
-      "integrity": "sha512-4SoW0yeAxgfcLIekKsvZVg/WgI5aQZyz9HGOoyBcVQ8coYoZmM9bAYQi+9zvyweqoWc+jgw72X1E8wtmMXt7Aw==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.4.tgz",
+      "integrity": "sha512-lApUzVPfCEz/4aot77qzWUNg7yQgT0JSzy3BrBm95+2TbgH894J9Fswhig0sEN9jxGSkc3A5Yp5fs1HJcPqUiw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -965,9 +965,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.0.3",
-        "@angular/common": "17.0.3",
-        "@angular/core": "17.0.3"
+        "@angular/animations": "17.0.4",
+        "@angular/common": "17.0.4",
+        "@angular/core": "17.0.4"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.3.tgz",
-      "integrity": "sha512-Ab6ZeGG63z9Ilv8r4lHcmSirVaw8quRrPjDbT8cgIteHbj0SbwgDzxX0ve+fjjubFUluNSNtc6OYglWMHJ/g7Q==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.4.tgz",
+      "integrity": "sha512-mZZNH+iFzFug0z7rBQKdFz375sR6Y4iBbHu2aJD2BpgA2/SJaZ0WHGlF4bHbtpCYkZi3f4wKF2+Cwe4G5ebPOQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -987,10 +987,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.0.3",
-        "@angular/compiler": "17.0.3",
-        "@angular/core": "17.0.3",
-        "@angular/platform-browser": "17.0.3"
+        "@angular/common": "17.0.4",
+        "@angular/compiler": "17.0.4",
+        "@angular/core": "17.0.4",
+        "@angular/platform-browser": "17.0.4"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.1.tgz",
-      "integrity": "sha512-IfiWIBY1GntfJFV/U1CSOHZ7zF5p0zFMFzux7/iGXUXit299LTdJ5mZTe9++lFcH6dPHgEPWlinuYAfzorY4ng==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.3.tgz",
+      "integrity": "sha512-H39WQ/tM6kOErfiyU6QkPasMtuOZHbm6INkirSR3ol4e93o6gLJ0ptwg3IQlyGtZK2QexWagPC6jzsdGIaN3iw==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4184,13 +4184,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.1.tgz",
-      "integrity": "sha512-BacI1fQsEXNYkfJzDJn3CsUSc9A4M7nhXtvt3XjceUhOqUp2AR4uIeUwDOrpLnkRwv5+rZLafUnRN3k01WUJOw==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.3.tgz",
+      "integrity": "sha512-pFHAqHMNm2WLoquJD4osSA/OAgH+wsFayPuqQnKjDEzeVW/YfJSbUksJ2iFt+uSfrhc/VxPf6pmGBMzi+9d0ng==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.1",
-        "@angular-devkit/schematics": "17.0.1",
+        "@angular-devkit/core": "17.0.3",
+        "@angular-devkit/schematics": "17.0.3",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -4340,9 +4340,9 @@
       }
     },
     "node_modules/@types/connect-history-api-fallback": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.3.tgz",
-      "integrity": "sha512-6mfQ6iNvhSKCZJoY6sIG3m0pKkdUcweVNOLuBBKvoWGzl2yRxOJcYOTRyLKt3nxXvBLJWa6QkW//tgbIwJehmA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+      "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
       "dev": true,
       "dependencies": {
         "@types/express-serve-static-core": "*",
@@ -4469,9 +4469,9 @@
       }
     },
     "node_modules/@types/node-forge": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.9.tgz",
-      "integrity": "sha512-meK88cx/sTalPSLSoCzkiUB4VPIFHmxtXm5FaaqRDqBX2i/Sy8bJ4odsan0b20RBjPh06dAQ+OTTdnyQyhJZyQ==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.10.tgz",
+      "integrity": "sha512-y6PJDYN4xYBxwd22l+OVH35N+1fCYWiuC3aiP2SlXVE6Lo7SS+rSx9r89hLxrP4pn6n1lBGhHJ12pj3F3Mpttw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -4566,9 +4566,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
-      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.0.3"
+    "@angular/core": "^17.0.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.0.1",
+    "@angular-devkit/build-angular": "^17.0.3",
     "@angular-eslint/builder": "^17.1.0",
     "@angular-eslint/eslint-plugin": "^17.1.0",
     "@angular-eslint/eslint-plugin-template": "^17.1.0",
     "@angular-eslint/schematics": "^17.1.0",
     "@angular-eslint/template-parser": "^17.1.0",
-    "@angular/cli": "^17.0.1",
-    "@angular/common": "^17.0.3",
-    "@angular/compiler": "^17.0.3",
-    "@angular/compiler-cli": "^17.0.3",
-    "@angular/platform-browser": "^17.0.3",
-    "@angular/platform-browser-dynamic": "^17.0.3",
+    "@angular/cli": "^17.0.3",
+    "@angular/common": "^17.0.4",
+    "@angular/compiler": "^17.0.4",
+    "@angular/compiler-cli": "^17.0.4",
+    "@angular/platform-browser": "^17.0.4",
+    "@angular/platform-browser-dynamic": "^17.0.4",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.9.5",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.0.1 -> 17.0.3         ng update @angular/cli
      @angular/core                           17.0.3 -> 17.0.4         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>