### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.0.5",
+        "@angular-devkit/build-angular": "^17.0.6",
         "@angular-eslint/builder": "^17.1.1",
         "@angular-eslint/eslint-plugin": "^17.1.1",
         "@angular-eslint/eslint-plugin-template": "^17.1.1",
         "@angular-eslint/schematics": "^17.1.1",
         "@angular-eslint/template-parser": "^17.1.1",
-        "@angular/cli": "^17.0.5",
-        "@angular/common": "^17.0.5",
-        "@angular/compiler": "^17.0.5",
-        "@angular/compiler-cli": "^17.0.5",
-        "@angular/platform-browser": "^17.0.5",
-        "@angular/platform-browser-dynamic": "^17.0.5",
+        "@angular/cli": "^17.0.6",
+        "@angular/common": "^17.0.6",
+        "@angular/compiler": "^17.0.6",
+        "@angular/compiler-cli": "^17.0.6",
+        "@angular/platform-browser": "^17.0.6",
+        "@angular/platform-browser-dynamic": "^17.0.6",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.10.4",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.2"
       },
       "peerDependencies": {
-        "@angular/core": "^17.0.5"
+        "@angular/core": "^17.0.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1700.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.5.tgz",
-      "integrity": "sha512-kPGiPzystxyLDj79Wy+wCZs5vzx6iUy6fjZ9dKFNS3M9T9UXoo8CZLJS0dWrgO/97M25MSgufyIEDmi+HvwZ7w==",
+      "version": "0.1700.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.6.tgz",
+      "integrity": "sha512-zVpz736cBZHXcv0v2bRLfJLcykanUyEMVQXkGwZp2eygjNK1Ls9s/74o1dXd6nGdvjh6AnkzOU/vouj2dqA41g==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.5",
+        "@angular-devkit/core": "17.0.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.5.tgz",
-      "integrity": "sha512-45+DTM3F8OFlMFRxQRgTBXnfndysgiZXiqItiKmFFau7wENZiTijUuFMFjOIHlLXFDI1qs130hYE4YkPNFffxg==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.6.tgz",
+      "integrity": "sha512-gYxmbvq5/nk7aVJ6JxIIW0//RM7859kMPJGPKekcCGSWkkObjqG6P5cDgJJNAjMl/IfCsG7B+xGYjr4zN8QV9g==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1700.5",
-        "@angular-devkit/build-webpack": "0.1700.5",
-        "@angular-devkit/core": "17.0.5",
+        "@angular-devkit/architect": "0.1700.6",
+        "@angular-devkit/build-webpack": "0.1700.6",
+        "@angular-devkit/core": "17.0.6",
         "@babel/core": "7.23.2",
         "@babel/generator": "7.23.0",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.23.2",
         "@babel/runtime": "7.23.2",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.0.5",
+        "@ngtools/webpack": "17.0.6",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.16",
@@ -153,7 +153,7 @@
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
         "undici": "5.27.2",
-        "vite": "4.5.0",
+        "vite": "4.5.1",
         "webpack": "5.89.0",
         "webpack-dev-middleware": "6.1.1",
         "webpack-dev-server": "4.15.1",
@@ -629,12 +629,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1700.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.5.tgz",
-      "integrity": "sha512-rLtDIK6je7JxhWG76aM8smfX13XHv+LlepwdK4lQqPEnz5BnkTfNFBnqwIWHA2eNUNTnVgeS356PxckZI3YL1g==",
+      "version": "0.1700.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.6.tgz",
+      "integrity": "sha512-xT5LL92rScVjvGZO7but/YbTQ12PNilosyjDouephl+HIf2V6rwDovTsEfpLYgcrqgodh+R0X0ZCOk95+MmSBA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.5",
+        "@angular-devkit/architect": "0.1700.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.5.tgz",
-      "integrity": "sha512-e1evgRabAfOZBnmFCe8E0oufcu+FzBe5hBzS94Dm42GlxdX965/M4yVKQxIMpjivQTmjl+AWb6cF1ltBdSGZeQ==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.6.tgz",
+      "integrity": "sha512-+h9VnFHof7rKzBJ5FWrbPXWzbag31QKbUGJ/mV5BYgj39vjzPNUXBW8AaScZAlATi8+tElYXjRMvM49GnuyRLg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -687,12 +687,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.5.tgz",
-      "integrity": "sha512-KYPku0qTb8B+TtRbFqXGYpJOPg1k6d5bNHV6n8jTc35mlEUUghOd7HkovdfkQ3cgGNQM56a74D1CvSeruZEGsA==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.6.tgz",
+      "integrity": "sha512-2g769MpazA1aOzJOm2MNGosra3kxw8CbdIQQOKkvycIzroRNgN06yHcRTDC03GADgP/CkDJ6kxwJQNG+wNFL2A==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.5",
+        "@angular-devkit/core": "17.0.6",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.5",
         "ora": "5.4.1",
@@ -825,15 +825,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.5.tgz",
-      "integrity": "sha512-IWtepjO1yTVGblbpTI7vtdxX5EjOYSL4BGa+3g85XuY6U2H38Bc9ZVBAYteAvRX1ZA2yvwJw068YY52ITlnr4A==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.6.tgz",
+      "integrity": "sha512-BLA2wDeqZManC/7MI6WvRRV+VhrwjxxB7FawLyp4xYlo0CTSOFOfeKPVRMLEnA/Ou4R5d47B+BqJTlep62pHwg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.5",
-        "@angular-devkit/core": "17.0.5",
-        "@angular-devkit/schematics": "17.0.5",
-        "@schematics/angular": "17.0.5",
+        "@angular-devkit/architect": "0.1700.6",
+        "@angular-devkit/core": "17.0.6",
+        "@angular-devkit/schematics": "17.0.6",
+        "@schematics/angular": "17.0.6",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.5.tgz",
-      "integrity": "sha512-1vFZ7nd8xyAYh/DwFtRuSieP8Dy/6QuOxl914/TOUr26F1a4e+7ywCyMLVjmYjx+WkZe7uu/Hgpr2raBaVTnQw==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.6.tgz",
+      "integrity": "sha512-FZtf8ol8W2V21ZDgFtcxmJ6JJKUO97QZ+wr/bosyYEryWMmn6VGrbOARhfW7BlrEgn14NdFkLb72KKtqoqRjrg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -885,14 +885,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.5",
+        "@angular/core": "17.0.6",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.5.tgz",
-      "integrity": "sha512-V6LnX/B2YXpzXeNWavtX/XPNUnWrVUFpiOniKqHYhAxXnibhyXL9DRsyVs8QbKgIcPPcQeJMHdAjklCWJsePvg==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.6.tgz",
+      "integrity": "sha512-PaCNnlPcL0rvByKCBUUyLWkKJYXOrcfKlYYvcacjOzEUgZeEpekG81hMRb9u/Pz+A+M4HJSTmdgzwGP35zo8qw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -901,7 +901,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.5"
+        "@angular/core": "17.0.6"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.5.tgz",
-      "integrity": "sha512-Nb99iKz8LMoc5HC9iu5rbWblXb68sHHI6bcN8sdqvc2g+PohkGNbtRjVZFhP+WKMaNFYDSvLWcHFFYItLRkT4g==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.6.tgz",
+      "integrity": "sha512-C1Gfh9kbjYZezEMOwxnvUTHuPXa+6pk7mAfSj8e5oAO6E+wfo2dTxv1J5zxa3KYzxPYMNfF8OFvLuMKsw7lXjA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -933,14 +933,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.0.5",
+        "@angular/compiler": "17.0.6",
         "typescript": ">=5.2 <5.3"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.5.tgz",
-      "integrity": "sha512-siWUrdBWgTAqMnRF+qxGZznj5AdR/x3+8l0/bj4CkSZzwZGL/CHy40ec71bbgiPkYob1v4v40voXu2aSSeCLPg==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.6.tgz",
+      "integrity": "sha512-QzfKRTDNgGOY9D5VxenUUz20cvPVC+uVw9xiqkDuHgGfLYVFlCAK9ymFYkdUCLTcVzJPxckP+spMpPX8nc4Aqw==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.5.tgz",
-      "integrity": "sha512-VJQ6bVS40xJLNGNcX59/QFPrZesIm2zETOqAc6K04onuWF1EnJqvcDog9eYJsm0sLWhQeCdWVmAFRenTkDoqng==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.6.tgz",
+      "integrity": "sha512-nBhWH1MKT2WswgRNIoMnmNAt0n5/fG59BanJtodW71//Aj5aIE+BuVoFgK3wmO8IMoeP4i4GXRInBXs6lUMOJw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -965,9 +965,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.0.5",
-        "@angular/common": "17.0.5",
-        "@angular/core": "17.0.5"
+        "@angular/animations": "17.0.6",
+        "@angular/common": "17.0.6",
+        "@angular/core": "17.0.6"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.5.tgz",
-      "integrity": "sha512-Ki+0B3/S+Rv3O4jf+tbDBPs0m+VUMoS6VVCCLviaurYGPLPtGblhCzRv49Zoyo5gEVoEOgnxS6CI91Tv6My9ug==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.6.tgz",
+      "integrity": "sha512-5ZEmBtBkqamTaWjUXCls7G1f3xyK/ykXE7hnUV9CgGqXKrNkxblmbtOhoWdsbuIYjjdxQcAk1qtg/Rg21wcc4w==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -987,10 +987,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.0.5",
-        "@angular/compiler": "17.0.5",
-        "@angular/core": "17.0.5",
-        "@angular/platform-browser": "17.0.5"
+        "@angular/common": "17.0.6",
+        "@angular/compiler": "17.0.6",
+        "@angular/core": "17.0.6",
+        "@angular/platform-browser": "17.0.6"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.5.tgz",
-      "integrity": "sha512-r82k7mxErJHtd6dzq0PKHQNhOuEjUZn95f2adJpO5mP/R/ms8LUk1ILvP3EocxkisYU8ET2EeGj3wQZC2g3RcA==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.6.tgz",
+      "integrity": "sha512-9Us20rqGhi8PmQBwQu6Qtww3WVV/gf2s2DbzcLclsiDtSBobzT64Z6F6E9OpAYD+c5PxlUaOghL6NXdnSNdByA==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4184,13 +4184,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.5.tgz",
-      "integrity": "sha512-sOc1UG4NiV+7cGwrbWPnyW71O+NgsKaFb2agSrVduRL7o4neMDeqF04ik4Kv1jKA7sZOQfPV+3cn6XI49Mumrw==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.6.tgz",
+      "integrity": "sha512-AyC7Bk3Omy6PfADThhq5ci+zzdTTi2N1oZI35gw4tMK5ZxVwIACx2Zyhaz399m5c2RCDi9Hz4A2BOFq9f0j/dg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.5",
-        "@angular-devkit/schematics": "17.0.5",
+        "@angular-devkit/core": "17.0.6",
+        "@angular-devkit/schematics": "17.0.6",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -18190,9 +18190,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.0.5"
+    "@angular/core": "^17.0.6"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.0.5",
+    "@angular-devkit/build-angular": "^17.0.6",
     "@angular-eslint/builder": "^17.1.1",
     "@angular-eslint/eslint-plugin": "^17.1.1",
     "@angular-eslint/eslint-plugin-template": "^17.1.1",
     "@angular-eslint/schematics": "^17.1.1",
     "@angular-eslint/template-parser": "^17.1.1",
-    "@angular/cli": "^17.0.5",
-    "@angular/common": "^17.0.5",
-    "@angular/compiler": "^17.0.5",
-    "@angular/compiler-cli": "^17.0.5",
-    "@angular/platform-browser": "^17.0.5",
-    "@angular/platform-browser-dynamic": "^17.0.5",
+    "@angular/cli": "^17.0.6",
+    "@angular/common": "^17.0.6",
+    "@angular/compiler": "^17.0.6",
+    "@angular/compiler-cli": "^17.0.6",
+    "@angular/platform-browser": "^17.0.6",
+    "@angular/platform-browser-dynamic": "^17.0.6",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.10.4",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.0.5 -> 17.0.6         ng update @angular/cli
      @angular/core                           17.0.5 -> 17.0.6         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>