### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.0.6",
+        "@angular-devkit/build-angular": "^17.0.7",
         "@angular-eslint/builder": "^17.1.1",
         "@angular-eslint/eslint-plugin": "^17.1.1",
         "@angular-eslint/eslint-plugin-template": "^17.1.1",
         "@angular-eslint/schematics": "^17.1.1",
         "@angular-eslint/template-parser": "^17.1.1",
-        "@angular/cli": "^17.0.6",
-        "@angular/common": "^17.0.6",
-        "@angular/compiler": "^17.0.6",
-        "@angular/compiler-cli": "^17.0.6",
-        "@angular/platform-browser": "^17.0.6",
-        "@angular/platform-browser-dynamic": "^17.0.6",
+        "@angular/cli": "^17.0.7",
+        "@angular/common": "^17.0.7",
+        "@angular/compiler": "^17.0.7",
+        "@angular/compiler-cli": "^17.0.7",
+        "@angular/platform-browser": "^17.0.7",
+        "@angular/platform-browser-dynamic": "^17.0.7",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.10.4",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.2"
       },
       "peerDependencies": {
-        "@angular/core": "^17.0.6"
+        "@angular/core": "^17.0.7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1700.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.6.tgz",
-      "integrity": "sha512-zVpz736cBZHXcv0v2bRLfJLcykanUyEMVQXkGwZp2eygjNK1Ls9s/74o1dXd6nGdvjh6AnkzOU/vouj2dqA41g==",
+      "version": "0.1700.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.7.tgz",
+      "integrity": "sha512-32uitQKsYLGXAKoXBsmOnPsTt9pS+b9cnFI9ZvBFVhJ31I2EOM7vGcMFalhTxdB/DkVHk4TyO78efV0V26DwCA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.6",
+        "@angular-devkit/core": "17.0.7",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.6.tgz",
-      "integrity": "sha512-gYxmbvq5/nk7aVJ6JxIIW0//RM7859kMPJGPKekcCGSWkkObjqG6P5cDgJJNAjMl/IfCsG7B+xGYjr4zN8QV9g==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.7.tgz",
+      "integrity": "sha512-AtEzLk6n6BXqQzk0Bsupe6GV0IgUe7RbpBfqROi+NZqMA7OUAHCX3xA6M68Qu+5KxBtW7T5lHeZZ7iP/y39wtQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1700.6",
-        "@angular-devkit/build-webpack": "0.1700.6",
-        "@angular-devkit/core": "17.0.6",
+        "@angular-devkit/architect": "0.1700.7",
+        "@angular-devkit/build-webpack": "0.1700.7",
+        "@angular-devkit/core": "17.0.7",
         "@babel/core": "7.23.2",
         "@babel/generator": "7.23.0",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.23.2",
         "@babel/runtime": "7.23.2",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.0.6",
+        "@ngtools/webpack": "17.0.7",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.16",
@@ -629,12 +629,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1700.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.6.tgz",
-      "integrity": "sha512-xT5LL92rScVjvGZO7but/YbTQ12PNilosyjDouephl+HIf2V6rwDovTsEfpLYgcrqgodh+R0X0ZCOk95+MmSBA==",
+      "version": "0.1700.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.7.tgz",
+      "integrity": "sha512-B9Mg/qYDpE5my8PJ3VPQyRSUV0Oq1bFUzU8s0ZpqEZl1URKc04pm0LtLmebrMIcUZgDiGk0RHaD+O1E9IV/bdQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.6",
+        "@angular-devkit/architect": "0.1700.7",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.6.tgz",
-      "integrity": "sha512-+h9VnFHof7rKzBJ5FWrbPXWzbag31QKbUGJ/mV5BYgj39vjzPNUXBW8AaScZAlATi8+tElYXjRMvM49GnuyRLg==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.7.tgz",
+      "integrity": "sha512-vATobHo5O5tJba424hJfQWLb40GzvZPNsI74dcgSUTgrDph8ksmk5xB9OvEvf0INorQZ2IMphj/VIWj4/+JqSA==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -687,12 +687,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.6.tgz",
-      "integrity": "sha512-2g769MpazA1aOzJOm2MNGosra3kxw8CbdIQQOKkvycIzroRNgN06yHcRTDC03GADgP/CkDJ6kxwJQNG+wNFL2A==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.7.tgz",
+      "integrity": "sha512-BY11OkJkM3xyXcvyD7x5kGY/c8Ufd4AfPvI0D9imhVxbns45Q48b1DlvCQvSnCJ/s+OwnkrYb/Efa70ZiaGu8A==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.6",
+        "@angular-devkit/core": "17.0.7",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.5",
         "ora": "5.4.1",
@@ -825,15 +825,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.6.tgz",
-      "integrity": "sha512-BLA2wDeqZManC/7MI6WvRRV+VhrwjxxB7FawLyp4xYlo0CTSOFOfeKPVRMLEnA/Ou4R5d47B+BqJTlep62pHwg==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.7.tgz",
+      "integrity": "sha512-oSa0GVAQNA7wFbLJYeaO3kV4iUcbKEqXDLxcIE8s1GfHddBOlXH2P1T4fXonCBl5qvV+joP0G0+fs7I0w2utZQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.6",
-        "@angular-devkit/core": "17.0.6",
-        "@angular-devkit/schematics": "17.0.6",
-        "@schematics/angular": "17.0.6",
+        "@angular-devkit/architect": "0.1700.7",
+        "@angular-devkit/core": "17.0.7",
+        "@angular-devkit/schematics": "17.0.7",
+        "@schematics/angular": "17.0.7",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.6.tgz",
-      "integrity": "sha512-FZtf8ol8W2V21ZDgFtcxmJ6JJKUO97QZ+wr/bosyYEryWMmn6VGrbOARhfW7BlrEgn14NdFkLb72KKtqoqRjrg==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.7.tgz",
+      "integrity": "sha512-bPPL6x0KOAOTxKSE2j4EWmEUOnqZYzOYiHzroa5b9UEyA9NvGkd9bm3zIxw8xcndRj1Ehcmvpi6KBLcYBBbWfg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -885,14 +885,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.6",
+        "@angular/core": "17.0.7",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.6.tgz",
-      "integrity": "sha512-PaCNnlPcL0rvByKCBUUyLWkKJYXOrcfKlYYvcacjOzEUgZeEpekG81hMRb9u/Pz+A+M4HJSTmdgzwGP35zo8qw==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.7.tgz",
+      "integrity": "sha512-QHPuLti2c2tGZmOGZ0cfCHo4LxiHUkC27I0aZFDyQSSQqEI5obQGVlEREHysw0nsS3sYIcLvqcwcKcRtXlXtxQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -901,7 +901,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.6"
+        "@angular/core": "17.0.7"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.6.tgz",
-      "integrity": "sha512-C1Gfh9kbjYZezEMOwxnvUTHuPXa+6pk7mAfSj8e5oAO6E+wfo2dTxv1J5zxa3KYzxPYMNfF8OFvLuMKsw7lXjA==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.7.tgz",
+      "integrity": "sha512-YnL38idjIYtl3BXYpv+sVJKWGbUjHT6eyQSQVAfO/1AwWqVa21K9hnE+Q37VmUKEcKFMnQembeuErA+KVsGI6A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -933,14 +933,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.0.6",
+        "@angular/compiler": "17.0.7",
         "typescript": ">=5.2 <5.3"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.6.tgz",
-      "integrity": "sha512-QzfKRTDNgGOY9D5VxenUUz20cvPVC+uVw9xiqkDuHgGfLYVFlCAK9ymFYkdUCLTcVzJPxckP+spMpPX8nc4Aqw==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.7.tgz",
+      "integrity": "sha512-mEkelXkzEi6+A9GjdKOSGGzQAfo1iAjVTn6YsplNUeGE5JgDZYZ7sXGQqs0Lin7dzJxnPAgGjCOl7SpWLXIPSQ==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.6.tgz",
-      "integrity": "sha512-nBhWH1MKT2WswgRNIoMnmNAt0n5/fG59BanJtodW71//Aj5aIE+BuVoFgK3wmO8IMoeP4i4GXRInBXs6lUMOJw==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.7.tgz",
+      "integrity": "sha512-bm9/wt51nc/MPjft/FlRNIgFSeLjDtfJOT7M32Rt6kOHhNKSK7ZTPWdMe9ahuHSbAhLzd0G/4NsT5sKrWSeVZg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -965,9 +965,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.0.6",
-        "@angular/common": "17.0.6",
-        "@angular/core": "17.0.6"
+        "@angular/animations": "17.0.7",
+        "@angular/common": "17.0.7",
+        "@angular/core": "17.0.7"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.6.tgz",
-      "integrity": "sha512-5ZEmBtBkqamTaWjUXCls7G1f3xyK/ykXE7hnUV9CgGqXKrNkxblmbtOhoWdsbuIYjjdxQcAk1qtg/Rg21wcc4w==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.7.tgz",
+      "integrity": "sha512-OquwUX9fLWA2JUZW5Jm6atk0CPt0sA7Tg24eGLsr6g1XfTS7jRZprlGaa72NgPLnQVV6m84o/ZiNYS6yPmq1Gg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -987,10 +987,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.0.6",
-        "@angular/compiler": "17.0.6",
-        "@angular/core": "17.0.6",
-        "@angular/platform-browser": "17.0.6"
+        "@angular/common": "17.0.7",
+        "@angular/compiler": "17.0.7",
+        "@angular/core": "17.0.7",
+        "@angular/platform-browser": "17.0.7"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.6.tgz",
-      "integrity": "sha512-9Us20rqGhi8PmQBwQu6Qtww3WVV/gf2s2DbzcLclsiDtSBobzT64Z6F6E9OpAYD+c5PxlUaOghL6NXdnSNdByA==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.7.tgz",
+      "integrity": "sha512-gwhUhpwXn0trwwKdSu9WlJbEcLt+s/2fPwoD9lZ0y3wXfrOogsfcNBJKeO5BZf1h+A3AWt7ePmgrZXSJM+865Q==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4184,13 +4184,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.6.tgz",
-      "integrity": "sha512-AyC7Bk3Omy6PfADThhq5ci+zzdTTi2N1oZI35gw4tMK5ZxVwIACx2Zyhaz399m5c2RCDi9Hz4A2BOFq9f0j/dg==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.7.tgz",
+      "integrity": "sha512-d7QKmcKrM4owb/2bR7Ipf23roiNbvbD/x7reNhQAtKAPLSHJ3Ulkf1+Yv+dj+9f+K7y9SBviEUSrD27BQ9WaxQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.6",
-        "@angular-devkit/schematics": "17.0.6",
+        "@angular-devkit/core": "17.0.7",
+        "@angular-devkit/schematics": "17.0.7",
         "jsonc-parser": "3.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.0.6"
+    "@angular/core": "^17.0.7"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.0.6",
+    "@angular-devkit/build-angular": "^17.0.7",
     "@angular-eslint/builder": "^17.1.1",
     "@angular-eslint/eslint-plugin": "^17.1.1",
     "@angular-eslint/eslint-plugin-template": "^17.1.1",
     "@angular-eslint/schematics": "^17.1.1",
     "@angular-eslint/template-parser": "^17.1.1",
-    "@angular/cli": "^17.0.6",
-    "@angular/common": "^17.0.6",
-    "@angular/compiler": "^17.0.6",
-    "@angular/compiler-cli": "^17.0.6",
-    "@angular/platform-browser": "^17.0.6",
-    "@angular/platform-browser-dynamic": "^17.0.6",
+    "@angular/cli": "^17.0.7",
+    "@angular/common": "^17.0.7",
+    "@angular/compiler": "^17.0.7",
+    "@angular/compiler-cli": "^17.0.7",
+    "@angular/platform-browser": "^17.0.7",
+    "@angular/platform-browser-dynamic": "^17.0.7",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.10.4",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.0.6 -> 17.0.7         ng update @angular/cli
      @angular/core                           17.0.6 -> 17.0.7         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>