### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.0.7",
+        "@angular-devkit/build-angular": "^17.0.8",
         "@angular-eslint/builder": "^17.1.1",
         "@angular-eslint/eslint-plugin": "^17.1.1",
         "@angular-eslint/eslint-plugin-template": "^17.1.1",
         "@angular-eslint/schematics": "^17.1.1",
         "@angular-eslint/template-parser": "^17.1.1",
-        "@angular/cli": "^17.0.7",
-        "@angular/common": "^17.0.7",
-        "@angular/compiler": "^17.0.7",
-        "@angular/compiler-cli": "^17.0.7",
-        "@angular/platform-browser": "^17.0.7",
-        "@angular/platform-browser-dynamic": "^17.0.7",
+        "@angular/cli": "^17.0.8",
+        "@angular/common": "^17.0.8",
+        "@angular/compiler": "^17.0.8",
+        "@angular/compiler-cli": "^17.0.8",
+        "@angular/platform-browser": "^17.0.8",
+        "@angular/platform-browser-dynamic": "^17.0.8",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.10.5",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.2"
       },
       "peerDependencies": {
-        "@angular/core": "^17.0.7"
+        "@angular/core": "^17.0.8"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1700.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.7.tgz",
-      "integrity": "sha512-32uitQKsYLGXAKoXBsmOnPsTt9pS+b9cnFI9ZvBFVhJ31I2EOM7vGcMFalhTxdB/DkVHk4TyO78efV0V26DwCA==",
+      "version": "0.1700.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.8.tgz",
+      "integrity": "sha512-SWVr3CvwO6T0yW2ytszCwBT1g92vyFkwbVUxqE93urYnoD8PvP+81GH5YwVjHQTgvhP4eXQMGZ9hpHx57VOrWQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.7",
+        "@angular-devkit/core": "17.0.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.7.tgz",
-      "integrity": "sha512-AtEzLk6n6BXqQzk0Bsupe6GV0IgUe7RbpBfqROi+NZqMA7OUAHCX3xA6M68Qu+5KxBtW7T5lHeZZ7iP/y39wtQ==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.8.tgz",
+      "integrity": "sha512-u7R5yX92ZxOL/LfxiKGGqlBo86100sJ5Rabavn8DeGtYP8N0qgwCcNwlW2zaMoUlkw2geMnxcxIX5VJI4iFPUA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1700.7",
-        "@angular-devkit/build-webpack": "0.1700.7",
-        "@angular-devkit/core": "17.0.7",
+        "@angular-devkit/architect": "0.1700.8",
+        "@angular-devkit/build-webpack": "0.1700.8",
+        "@angular-devkit/core": "17.0.8",
         "@babel/core": "7.23.2",
         "@babel/generator": "7.23.0",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.23.2",
         "@babel/runtime": "7.23.2",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.0.7",
+        "@ngtools/webpack": "17.0.8",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.16",
@@ -629,12 +629,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1700.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.7.tgz",
-      "integrity": "sha512-B9Mg/qYDpE5my8PJ3VPQyRSUV0Oq1bFUzU8s0ZpqEZl1URKc04pm0LtLmebrMIcUZgDiGk0RHaD+O1E9IV/bdQ==",
+      "version": "0.1700.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.8.tgz",
+      "integrity": "sha512-GA7QlCAlYB3uBkRaUYgIC/Vfajb9jMmouwYiAAEm34ZyP3ThFjdqsYd/A/exnuESt5o6Bh++C/PI34sV3lawRA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.7",
+        "@angular-devkit/architect": "0.1700.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.7.tgz",
-      "integrity": "sha512-vATobHo5O5tJba424hJfQWLb40GzvZPNsI74dcgSUTgrDph8ksmk5xB9OvEvf0INorQZ2IMphj/VIWj4/+JqSA==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.8.tgz",
+      "integrity": "sha512-gI8+SOwGUwr0WOlFrhLjohLolMzcguuoR0LTZEcGjdXvQyPgH4NDSRIIrfWCdu+ZVhfy76o3zQYdYc9QN8NrjQ==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -687,12 +687,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.7.tgz",
-      "integrity": "sha512-BY11OkJkM3xyXcvyD7x5kGY/c8Ufd4AfPvI0D9imhVxbns45Q48b1DlvCQvSnCJ/s+OwnkrYb/Efa70ZiaGu8A==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.8.tgz",
+      "integrity": "sha512-syo814SVWfJvne448IijjZvpWbuqJsEutdNqHWLTewTfX2U3KrIAr/XRVcXQMuyMvLCDiuxjMgEJxOIP7mcIPw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.7",
+        "@angular-devkit/core": "17.0.8",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.5",
         "ora": "5.4.1",
@@ -825,15 +825,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.7.tgz",
-      "integrity": "sha512-oSa0GVAQNA7wFbLJYeaO3kV4iUcbKEqXDLxcIE8s1GfHddBOlXH2P1T4fXonCBl5qvV+joP0G0+fs7I0w2utZQ==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.8.tgz",
+      "integrity": "sha512-yZXYNLAFv9u2qypsVqtS+rRCsnjsIPYXr6TcI/r5buzOtC7UQ2lleYsWJqX47SsyGMk/o3gaYg5Bj2I5mmRDLA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.7",
-        "@angular-devkit/core": "17.0.7",
-        "@angular-devkit/schematics": "17.0.7",
-        "@schematics/angular": "17.0.7",
+        "@angular-devkit/architect": "0.1700.8",
+        "@angular-devkit/core": "17.0.8",
+        "@angular-devkit/schematics": "17.0.8",
+        "@schematics/angular": "17.0.8",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.7.tgz",
-      "integrity": "sha512-bPPL6x0KOAOTxKSE2j4EWmEUOnqZYzOYiHzroa5b9UEyA9NvGkd9bm3zIxw8xcndRj1Ehcmvpi6KBLcYBBbWfg==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.8.tgz",
+      "integrity": "sha512-fFfwtdg7H+OkqnvV/ENu8F8KGfgIiH16DDbQqYY5KQyyQB+SMsoVW29F1fGx6Y30s7ZlsLOy6cHhgrw74itkSw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -885,14 +885,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.7",
+        "@angular/core": "17.0.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.7.tgz",
-      "integrity": "sha512-QHPuLti2c2tGZmOGZ0cfCHo4LxiHUkC27I0aZFDyQSSQqEI5obQGVlEREHysw0nsS3sYIcLvqcwcKcRtXlXtxQ==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.8.tgz",
+      "integrity": "sha512-48jWypuhBGTrUUbkz1vB9gjbKKZ3hpuJ2DUUncd331Yw4tqkqZQbBa/E3ei4IHiCxEvW2uX3lI4AwlhuozmUtA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -901,7 +901,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.7"
+        "@angular/core": "17.0.8"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.7.tgz",
-      "integrity": "sha512-YnL38idjIYtl3BXYpv+sVJKWGbUjHT6eyQSQVAfO/1AwWqVa21K9hnE+Q37VmUKEcKFMnQembeuErA+KVsGI6A==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.8.tgz",
+      "integrity": "sha512-ny2SMVgl+icjMuU5ZM57yFGUrhjR0hNxfCn0otAD3jUFliz/Onu9l6EPRKA5Cr8MZx3mg3rTLSBMD17YT8rsOg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -933,14 +933,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.0.7",
+        "@angular/compiler": "17.0.8",
         "typescript": ">=5.2 <5.3"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.7.tgz",
-      "integrity": "sha512-mEkelXkzEi6+A9GjdKOSGGzQAfo1iAjVTn6YsplNUeGE5JgDZYZ7sXGQqs0Lin7dzJxnPAgGjCOl7SpWLXIPSQ==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.8.tgz",
+      "integrity": "sha512-tzYsK24LdkNuKNJK6efF4XOqspvF/qOe9j/n1Y61a6mNvFwsJFGbcmdZMby4hI/YRm6oIDoIIFjSep8ycp6Pbw==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.7.tgz",
-      "integrity": "sha512-bm9/wt51nc/MPjft/FlRNIgFSeLjDtfJOT7M32Rt6kOHhNKSK7ZTPWdMe9ahuHSbAhLzd0G/4NsT5sKrWSeVZg==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.8.tgz",
+      "integrity": "sha512-XaI+p2AxQaIHzR761lhPUf4OcOp46WDW0IfbvOzaezHE+8r81joZyVSDQPgXSa/aRfI58YhcfUavuGqyU3PphA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -965,9 +965,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.0.7",
-        "@angular/common": "17.0.7",
-        "@angular/core": "17.0.7"
+        "@angular/animations": "17.0.8",
+        "@angular/common": "17.0.8",
+        "@angular/core": "17.0.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.7.tgz",
-      "integrity": "sha512-OquwUX9fLWA2JUZW5Jm6atk0CPt0sA7Tg24eGLsr6g1XfTS7jRZprlGaa72NgPLnQVV6m84o/ZiNYS6yPmq1Gg==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.8.tgz",
+      "integrity": "sha512-BIXNKnfBZb8sdluQ7WIhIXFuVnsJJ0SV+aiMKzQ7B6XhWoAXZQnlvON2thydjIIVuCvaF3YmWTbILI2K8YZ2jQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -987,10 +987,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.0.7",
-        "@angular/compiler": "17.0.7",
-        "@angular/core": "17.0.7",
-        "@angular/platform-browser": "17.0.7"
+        "@angular/common": "17.0.8",
+        "@angular/compiler": "17.0.8",
+        "@angular/core": "17.0.8",
+        "@angular/platform-browser": "17.0.8"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.7.tgz",
-      "integrity": "sha512-gwhUhpwXn0trwwKdSu9WlJbEcLt+s/2fPwoD9lZ0y3wXfrOogsfcNBJKeO5BZf1h+A3AWt7ePmgrZXSJM+865Q==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.8.tgz",
+      "integrity": "sha512-wx0XBMrbpDeailK2uIhp/ZVMC3GK3BWwJjUu5SbT4BFrcoi2Zd9/9m0RCBAY54UXLBCqKd+ih7pJ6JSvprZmWw==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4184,13 +4184,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.7.tgz",
-      "integrity": "sha512-d7QKmcKrM4owb/2bR7Ipf23roiNbvbD/x7reNhQAtKAPLSHJ3Ulkf1+Yv+dj+9f+K7y9SBviEUSrD27BQ9WaxQ==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.8.tgz",
+      "integrity": "sha512-1h5mwKFv1B/L5JWZ0mxnC4ms06iwnSi/w+GgRZPeM3P5BpuZuvAkFiClNnM55iLlQJXRQioPNLM3sOsz7spR6w==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.7",
-        "@angular-devkit/schematics": "17.0.7",
+        "@angular-devkit/core": "17.0.8",
+        "@angular-devkit/schematics": "17.0.8",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -4490,9 +4490,9 @@
       "peer": true
     },
     "node_modules/@types/qs": {
-      "version": "6.9.10",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
+      "version": "6.9.11",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
       "dev": true
     },
     "node_modules/@types/range-parser": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.0.7"
+    "@angular/core": "^17.0.8"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.0.7",
+    "@angular-devkit/build-angular": "^17.0.8",
     "@angular-eslint/builder": "^17.1.1",
     "@angular-eslint/eslint-plugin": "^17.1.1",
     "@angular-eslint/eslint-plugin-template": "^17.1.1",
     "@angular-eslint/schematics": "^17.1.1",
     "@angular-eslint/template-parser": "^17.1.1",
-    "@angular/cli": "^17.0.7",
-    "@angular/common": "^17.0.7",
-    "@angular/compiler": "^17.0.7",
-    "@angular/compiler-cli": "^17.0.7",
-    "@angular/platform-browser": "^17.0.7",
-    "@angular/platform-browser-dynamic": "^17.0.7",
+    "@angular/cli": "^17.0.8",
+    "@angular/common": "^17.0.8",
+    "@angular/compiler": "^17.0.8",
+    "@angular/compiler-cli": "^17.0.8",
+    "@angular/platform-browser": "^17.0.8",
+    "@angular/platform-browser-dynamic": "^17.0.8",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.10.5",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.0.7 -> 17.0.8         ng update @angular/cli
      @angular/core                           17.0.7 -> 17.0.8         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>