### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.0.9",
+        "@angular-devkit/build-angular": "^17.0.10",
         "@angular-eslint/builder": "^17.2.0",
         "@angular-eslint/eslint-plugin": "^17.2.0",
         "@angular-eslint/eslint-plugin-template": "^17.2.0",
         "@angular-eslint/schematics": "^17.2.0",
         "@angular-eslint/template-parser": "^17.2.0",
-        "@angular/cli": "^17.0.9",
-        "@angular/common": "^17.0.8",
-        "@angular/compiler": "^17.0.8",
-        "@angular/compiler-cli": "^17.0.8",
-        "@angular/platform-browser": "^17.0.8",
-        "@angular/platform-browser-dynamic": "^17.0.8",
+        "@angular/cli": "^17.0.10",
+        "@angular/common": "^17.0.9",
+        "@angular/compiler": "^17.0.9",
+        "@angular/compiler-cli": "^17.0.9",
+        "@angular/platform-browser": "^17.0.9",
+        "@angular/platform-browser-dynamic": "^17.0.9",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.11.0",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.3"
       },
       "peerDependencies": {
-        "@angular/core": "^17.0.8"
+        "@angular/core": "^17.0.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1700.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.9.tgz",
-      "integrity": "sha512-B8OeUrvJj5JsfOJIibpoVjvuZzthPFxf1LvuUXTyQcqDUscJAe/RJBc2woT6ss13Iv/HWt8mgaMPP4CccckdNg==",
+      "version": "0.1700.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.10.tgz",
+      "integrity": "sha512-JD/3jkdN1jrFMIDEk9grKdbjutIoxUDMRazq1LZooWjTkzlYk09i/s6HwvIPao7zvxJfelD6asTPspgkjOMP5A==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.9",
+        "@angular-devkit/core": "17.0.10",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.9.tgz",
-      "integrity": "sha512-yH6AfR2/CXrp05dIFQCroyl6Eaq8mS6tt4P7yS48+KXvAbQq2KzYW+TrDD4flFXe3qLVQGFpds3jE2auiwhHsA==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.10.tgz",
+      "integrity": "sha512-RWVu5Pdg6VdO3v1i0oI+HGr/NE4rhbNelM43w+9TqrzDtwmvckWsadSp0H88cPhQ4YGY5ldGKyQufO1UItR26w==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1700.9",
-        "@angular-devkit/build-webpack": "0.1700.9",
-        "@angular-devkit/core": "17.0.9",
+        "@angular-devkit/architect": "0.1700.10",
+        "@angular-devkit/build-webpack": "0.1700.10",
+        "@angular-devkit/core": "17.0.10",
         "@babel/core": "7.23.2",
         "@babel/generator": "7.23.0",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.23.2",
         "@babel/runtime": "7.23.2",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.0.9",
+        "@ngtools/webpack": "17.0.10",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.16",
@@ -629,12 +629,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1700.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.9.tgz",
-      "integrity": "sha512-NBpTb5kdnTePtNirsJQFXfOIFKTPdDqJe0b0sI3FI860po7uvUFu1m5pL5QSkJLmdqrjfPkNq7svGf7NlHQ8JA==",
+      "version": "0.1700.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.10.tgz",
+      "integrity": "sha512-jjcH5zGWre+adnVqjBdAr04Yto8oG6j7fFWuoiBVWEtK8AmesukGJQY8+QKX5UcrsyjP7COsfbz5WeJk3g1KOg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.9",
+        "@angular-devkit/architect": "0.1700.10",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.9.tgz",
-      "integrity": "sha512-r5jqwpWOgowqe9KSDqJ3iSbmsEt2XPjSvRG4DSI2T9s31bReoMtreo8b7wkRa2B3hbcDnstFbn8q27VvJDqRaQ==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.10.tgz",
+      "integrity": "sha512-93N6oHnmtRt0hL3AXxvnk47sN1rHndfj+pqI5haEY41AGWzIWv9cSBsqlM0PWltNpo6VivcExZESvbLJ71wqbQ==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -687,12 +687,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.9.tgz",
-      "integrity": "sha512-5ti7g45F2KjDJS0DbgnOGI1GyKxGpn4XsKTYJFJrSAWj6VpuvPy/DINRrXNuRVo09VPEkqA+IW7QwaG9icptQg==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.10.tgz",
+      "integrity": "sha512-hjf4gaMx2uB6ZhBstBSH0Q2hzfp6kxI4IiJ5i1QrxPNE1MdGnb2h+LgPTRCdO72a7PGeWcSxFRE7cxrXeQy19g==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.9",
+        "@angular-devkit/core": "17.0.10",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.5",
         "ora": "5.4.1",
@@ -828,15 +828,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.9.tgz",
-      "integrity": "sha512-a1rLAu3TNU5d56ozBnx9UZchJDKC8qMvZL4ThJhcaTUJb0Cj//gqLJdNdMcB0p1Ve9lmmAQ3J17+2Xij1u3sNg==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.10.tgz",
+      "integrity": "sha512-52rd8KmOMe3NJDp/wA+Mwj21qd4HR8fuLtfrErgVnZaJZKX2Bzi/z7FHQD3gdgMAdzUiG0OJWGM0h75Ls9X6Gw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.9",
-        "@angular-devkit/core": "17.0.9",
-        "@angular-devkit/schematics": "17.0.9",
-        "@schematics/angular": "17.0.9",
+        "@angular-devkit/architect": "0.1700.10",
+        "@angular-devkit/core": "17.0.10",
+        "@angular-devkit/schematics": "17.0.10",
+        "@schematics/angular": "17.0.10",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.8.tgz",
-      "integrity": "sha512-fFfwtdg7H+OkqnvV/ENu8F8KGfgIiH16DDbQqYY5KQyyQB+SMsoVW29F1fGx6Y30s7ZlsLOy6cHhgrw74itkSw==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.9.tgz",
+      "integrity": "sha512-xNS7DDfvFqfLr6xeZNJ+jORuGXP6hhv2HsYD3jb6ZQ8+QuMg+3MDij4a0L5npn72gH/Zz4JRKZ3Bt4Cq6cUqUA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -888,14 +888,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.8",
+        "@angular/core": "17.0.9",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.8.tgz",
-      "integrity": "sha512-48jWypuhBGTrUUbkz1vB9gjbKKZ3hpuJ2DUUncd331Yw4tqkqZQbBa/E3ei4IHiCxEvW2uX3lI4AwlhuozmUtA==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.9.tgz",
+      "integrity": "sha512-xf0JChGttVoYPh0PRV3KnbujtlNFavcYzElS6W8iW64O+2HaSxaquWnolcgL5QT1rNGp4s/TxsttloLhbqxNmw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -904,7 +904,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.0.8"
+        "@angular/core": "17.0.9"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -913,9 +913,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.8.tgz",
-      "integrity": "sha512-ny2SMVgl+icjMuU5ZM57yFGUrhjR0hNxfCn0otAD3jUFliz/Onu9l6EPRKA5Cr8MZx3mg3rTLSBMD17YT8rsOg==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.9.tgz",
+      "integrity": "sha512-fpbs8ZuHi2Z/uOIAxEICzQ1aYbc8Z2TOjB0PDP1RJ1kQmtlWNWxgMqV/uJ59sJO9AMYxc496msMtmOa3OByPYQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -936,14 +936,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.0.8",
+        "@angular/compiler": "17.0.9",
         "typescript": ">=5.2 <5.3"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.8.tgz",
-      "integrity": "sha512-tzYsK24LdkNuKNJK6efF4XOqspvF/qOe9j/n1Y61a6mNvFwsJFGbcmdZMby4hI/YRm6oIDoIIFjSep8ycp6Pbw==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.9.tgz",
+      "integrity": "sha512-LtDWzyx19XNmAjXju9xjw//rDZPUFu2bllHqzS6NVO1bE4PwJHIs0zfvygh0j46ubKp1gUICNk3jvYK9FMVinA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -957,9 +957,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.8.tgz",
-      "integrity": "sha512-XaI+p2AxQaIHzR761lhPUf4OcOp46WDW0IfbvOzaezHE+8r81joZyVSDQPgXSa/aRfI58YhcfUavuGqyU3PphA==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.9.tgz",
+      "integrity": "sha512-Edz039lTJ9tHR6VEPHXUcQHqdCXAhJcdPoWSWsUBJ30eZFx0VlxQEb4ujlz8LBgIVvthp5WYhHMjd/ueWzEINw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -968,9 +968,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.0.8",
-        "@angular/common": "17.0.8",
-        "@angular/core": "17.0.8"
+        "@angular/animations": "17.0.9",
+        "@angular/common": "17.0.9",
+        "@angular/core": "17.0.9"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.8.tgz",
-      "integrity": "sha512-BIXNKnfBZb8sdluQ7WIhIXFuVnsJJ0SV+aiMKzQ7B6XhWoAXZQnlvON2thydjIIVuCvaF3YmWTbILI2K8YZ2jQ==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.0.9.tgz",
+      "integrity": "sha512-44wIecNzxEUi3T/bggeJsgK+iD7Snu64sqQg00ewsuFCMpaWwyC80LnTIff/QnBVoggAjXvEql6vwr3AZNTcuQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -990,10 +990,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.0.8",
-        "@angular/compiler": "17.0.8",
-        "@angular/core": "17.0.8",
-        "@angular/platform-browser": "17.0.8"
+        "@angular/common": "17.0.9",
+        "@angular/compiler": "17.0.9",
+        "@angular/core": "17.0.9",
+        "@angular/platform-browser": "17.0.9"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3495,9 +3495,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.9.tgz",
-      "integrity": "sha512-ilbzwW30NaccrhYbdY3jy/ZpbC0l7W6+L2Cd3dzHFQ1gZGckibDdMzjibW/vyq/vRf0xr25+oBVIqUn8kZ606g==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.10.tgz",
+      "integrity": "sha512-UCiLrV2aLrtR7Wr/jJi0nH2Xzb7ETenrPWU/EcW9V3lnlDun5g1J0y01jRzvcipxNTOmFfI4lqv288nKSmSOAA==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4187,13 +4187,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.9.tgz",
-      "integrity": "sha512-XPaHAhobxdQMswH8wSrfToKN7wmGJFh/K5jq/3J+78KeSBZStYxZkVIQbvJkSU8Y1MsdVaeMYKDE8rjFN83OYA==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.10.tgz",
+      "integrity": "sha512-rRBlDMXfVPkW3CqVQxazFqkuJXd0BFnD1zjI9WtDiNt3o2pTHbLzuWJnXKuIt5rzv0x/bFwNqIt4CPW2DYGNMg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.9",
-        "@angular-devkit/schematics": "17.0.9",
+        "@angular-devkit/core": "17.0.10",
+        "@angular-devkit/schematics": "17.0.10",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -6178,9 +6178,9 @@
       }
     },
     "node_modules/bonjour-service": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.0.tgz",
-      "integrity": "sha512-xdzMA6JGckxyJzZByjEWRcfKmDxXaGXZWVftah3FkCqdlePNS9DjHSUN5zkP4oEfz/t0EXXlro88EIhzwMB4zA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
+      "integrity": "sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.0.8"
+    "@angular/core": "^17.0.9"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.0.9",
+    "@angular-devkit/build-angular": "^17.0.10",
     "@angular-eslint/builder": "^17.2.0",
     "@angular-eslint/eslint-plugin": "^17.2.0",
     "@angular-eslint/eslint-plugin-template": "^17.2.0",
     "@angular-eslint/schematics": "^17.2.0",
     "@angular-eslint/template-parser": "^17.2.0",
-    "@angular/cli": "^17.0.9",
-    "@angular/common": "^17.0.8",
-    "@angular/compiler": "^17.0.8",
-    "@angular/compiler-cli": "^17.0.8",
-    "@angular/platform-browser": "^17.0.8",
-    "@angular/platform-browser-dynamic": "^17.0.8",
+    "@angular/cli": "^17.0.10",
+    "@angular/common": "^17.0.9",
+    "@angular/compiler": "^17.0.9",
+    "@angular/compiler-cli": "^17.0.9",
+    "@angular/platform-browser": "^17.0.9",
+    "@angular/platform-browser-dynamic": "^17.0.9",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.11.0",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.0.9 -> 17.0.10        ng update @angular/cli
      @angular/core                           17.0.8 -> 17.0.9         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>