### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.1.0",
+        "@angular-devkit/build-angular": "^17.1.1",
         "@angular-eslint/builder": "^17.2.1",
         "@angular-eslint/eslint-plugin": "^17.2.1",
         "@angular-eslint/eslint-plugin-template": "^17.2.1",
         "@angular-eslint/schematics": "^17.2.1",
         "@angular-eslint/template-parser": "^17.2.1",
-        "@angular/cli": "^17.1.0",
-        "@angular/common": "^17.1.0",
-        "@angular/compiler": "^17.1.0",
-        "@angular/compiler-cli": "^17.1.0",
-        "@angular/platform-browser": "^17.1.0",
-        "@angular/platform-browser-dynamic": "^17.1.0",
+        "@angular/cli": "^17.1.1",
+        "@angular/common": "^17.1.1",
+        "@angular/compiler": "^17.1.1",
+        "@angular/compiler-cli": "^17.1.1",
+        "@angular/platform-browser": "^17.1.1",
+        "@angular/platform-browser-dynamic": "^17.1.1",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.11.7",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.3"
       },
       "peerDependencies": {
-        "@angular/core": "^17.1.0"
+        "@angular/core": "^17.1.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1701.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1701.0.tgz",
-      "integrity": "sha512-VP6mjptKFn0HO2dn4bH0mFMe4CrexlWlgnTHyAUbL7ZFaV9w4VQuE/vXr60wMlQ+83NIGUeJImjt1QVNlIjJnQ==",
+      "version": "0.1701.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1701.1.tgz",
+      "integrity": "sha512-vT3ZRAIfNyIg0vJWT6umPbCKiKFCukNkxLe9kgOU0tinZKNr/LgWYaBZ92Rxxi6C3NrAnmAYjsih8x4zdyoRXw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.1.0",
+        "@angular-devkit/core": "17.1.1",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.1.0.tgz",
-      "integrity": "sha512-N9B2SlKewD48qKFgRPKDH1X2EvOGll1ocMlFxi95mT9aXuFd2d75JUYHzS1v3FQRU3peoAoFKxCV7OuIL/cmTA==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.1.1.tgz",
+      "integrity": "sha512-GchDM8H+RQNts731c+jnhDgOm0PnCS3YB12uVwRiGsaNsUMrqKnu3P0poh6AImDMPyXKnIvTWLDCMD8TDziR0A==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1701.0",
-        "@angular-devkit/build-webpack": "0.1701.0",
-        "@angular-devkit/core": "17.1.0",
+        "@angular-devkit/architect": "0.1701.1",
+        "@angular-devkit/build-webpack": "0.1701.1",
+        "@angular-devkit/core": "17.1.1",
         "@babel/core": "7.23.7",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.23.7",
         "@babel/runtime": "7.23.7",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.1.0",
+        "@ngtools/webpack": "17.1.1",
         "@vitejs/plugin-basic-ssl": "1.0.2",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.16",
@@ -151,7 +151,7 @@
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
         "undici": "6.2.1",
-        "vite": "5.0.11",
+        "vite": "5.0.12",
         "watchpack": "2.4.0",
         "webpack": "5.89.0",
         "webpack-dev-middleware": "6.1.1",
@@ -291,12 +291,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1701.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1701.0.tgz",
-      "integrity": "sha512-AUQbdnAXMdXKPj51RWr+0SusTh5M1EWEpXtEZgDSO5Vab6ak+xsX+k1IhjlEoliF0prHjD5WzBegr6WKCjZ30w==",
+      "version": "0.1701.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1701.1.tgz",
+      "integrity": "sha512-YgNl/6xLmI0XdUCu/H4Jyi34BhrANCDP4N2Pz+tGwnz2+Vl8oZGLPGtKVbh/LKSAmEHk/B6GQUekSBpKWrPJoA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1701.0",
+        "@angular-devkit/architect": "0.1701.1",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.1.0.tgz",
-      "integrity": "sha512-w7HeJjyM6YtjXrwFdmFIsp9lzDPAFJov8hVCD18DZaCwryRixz+o8egfw2SkpI4L8kuGAiGxpaCTRsTQtmR4/w==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.1.1.tgz",
+      "integrity": "sha512-b1wd1caegc1p18nTrfPhfHQAZW1GnWWKGldq5MZ8C/nkgJbjjN8SKb1Vw7GONkOnH6KxWDAXS4i93/wdQcz4Bg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -349,12 +349,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.1.0.tgz",
-      "integrity": "sha512-7q4Bk3+ePBdzrmMWxWBnNdN4kmBe2jJwa3vAofaMqZiIBEor85YcOsrUJvcWM/3+/TusgZr4p/4+oJgiYDrj5A==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.1.1.tgz",
+      "integrity": "sha512-3AtEO7k0Znzg11o51ZqebkW8063QkZ7Y7BC96Oye+wSdpT3ow57P0w0UtOpUNesNKzj1iMuPWqqm4i+YqitjCw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.1.0",
+        "@angular-devkit/core": "17.1.1",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.5",
         "ora": "5.4.1",
@@ -490,15 +490,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.1.0.tgz",
-      "integrity": "sha512-mZh8ibV94CqHls+GTHok9rF78UvrtKZx+o1QOcG50ZM1L5O5s2NYrBhf+QXVeTTmzhSH1wXQb7ueyuLNLVB/eA==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.1.1.tgz",
+      "integrity": "sha512-JG/Vf+PScR3PC6u7B+jFF4s5eBByzCpOfCfRFw98nlCqDAOxYOig7wi2Sbp5fnvILQH8vbc/NG8MzdgONrG6Hg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1701.0",
-        "@angular-devkit/core": "17.1.0",
-        "@angular-devkit/schematics": "17.1.0",
-        "@schematics/angular": "17.1.0",
+        "@angular-devkit/architect": "0.1701.1",
+        "@angular-devkit/core": "17.1.1",
+        "@angular-devkit/schematics": "17.1.1",
+        "@schematics/angular": "17.1.1",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -539,9 +539,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.1.0.tgz",
-      "integrity": "sha512-0Zg62iSynyRr2QslC8dVwSo46mkKrVENnwcBvsgTJ8rfGiuRdKMX8nWm5EUEm3ohKmYLfHvyEjsKDRn//UefVw==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.1.1.tgz",
+      "integrity": "sha512-YMM2vImWJg7H3Yaej7ncGpFKT28V2Y6X9/rLpRdSKAiUbcbj7GeWtX/upfZGR9KmD08baYZw0YTNMR03Ubv/mg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -550,14 +550,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.1.0",
+        "@angular/core": "17.1.1",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.1.0.tgz",
-      "integrity": "sha512-gF4i/WtPSiSvT4YNasTNnckOxdxuSNwi0EsncrtewwveBcCatjqaXNssUCiF5TgxlC2sKTmsPcMqDJrfX2LMpw==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.1.1.tgz",
+      "integrity": "sha512-lEQ5YNMJQm2iO2EZbGkwL3SqnxtE2ENfymgbS023F6ACsnP3kKB2DMwOnIbGgQY4+8r4sJFiMAIjEkj5c9kttg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -566,7 +566,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.1.0"
+        "@angular/core": "17.1.1"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.1.0.tgz",
-      "integrity": "sha512-WDpO4WvC5ItjaRexnpFpKPpT+cu+5GYkWF8h74iHhfxOgU+gaQiMWERHylWCqF25AzmhKu0iI3ZZtaIJ6qqwog==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.1.1.tgz",
+      "integrity": "sha512-d6Aev1P92q7wd5u3UcJifzNlU9svxaYI2Ts6MKoD4jY4/GPN/gPDqi20weDMujEgirrkcwGbsCXBRoEGkA5c9A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -598,14 +598,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.1.0",
+        "@angular/compiler": "17.1.1",
         "typescript": ">=5.2 <5.4"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.1.0.tgz",
-      "integrity": "sha512-9OvRRZq+46S+ICZLRYIGVU2pknuPz23B+5V3jz7cDA5V43GVcMnfmAbMClPQxm7kRGnqtQ+yzBjn+HubCerE6g==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.1.1.tgz",
+      "integrity": "sha512-JtNYM9eHr8eUSrGPq/kn0+/F+TSZ7EBWxZhM1ZndOlGu1gA4fGhrDid4ZXIHIs07DbM4NZjMn+LhRyx02YDsSA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -619,9 +619,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.1.0.tgz",
-      "integrity": "sha512-Klq92ZUX0+ZsxLvbYtIEP3GtVEfMLYPxmBP0pWNZyYIeJCg/YxPS76QSvEhBaMqFelk4RzkDQEIfixC16UIgOA==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.1.1.tgz",
+      "integrity": "sha512-/80znuEkdDvsF6EX/fe03isQlLCUS9+ldCgB4n0ZL+qAkf2/lJlU3n97SyEN7rzb189U+K1fDe0fb1nDwbbcWQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -630,9 +630,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.1.0",
-        "@angular/common": "17.1.0",
-        "@angular/core": "17.1.0"
+        "@angular/animations": "17.1.1",
+        "@angular/common": "17.1.1",
+        "@angular/core": "17.1.1"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.1.0.tgz",
-      "integrity": "sha512-rqPRZZx6VcSx81HIQr1XMBgb7fYSj6pOZNTJGZkn2KNxrz6hyU3A3qaom1VSVRK5vvNb1cFn35mg/zyOIliTIg==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.1.1.tgz",
+      "integrity": "sha512-UKI8966nwo+p01EjmQdkepLIeVLpPZTSDZAM4va7CfMO6lbCN5xFecDd/sVbut8J6ySIsbJxyDkP+SHMQjE+xg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -652,10 +652,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.1.0",
-        "@angular/compiler": "17.1.0",
-        "@angular/core": "17.1.0",
-        "@angular/platform-browser": "17.1.0"
+        "@angular/common": "17.1.1",
+        "@angular/compiler": "17.1.1",
+        "@angular/core": "17.1.1",
+        "@angular/platform-browser": "17.1.1"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.1.0.tgz",
-      "integrity": "sha512-FAp5Vh4Y4DFDnrxEitggEkeDwHCml7m6hZUgohvA6n6mwrMT0ZZXnk3MIrKRnT6A9cr1wcnxMW+jIXx/cJZGlw==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.1.1.tgz",
+      "integrity": "sha512-uPWEpRuAUmMBZhYMpkEHNbeI8QAgeVM5lnWM+02lK75u1+sgYy32ed+RcRvEI+8hRQcsCQ8HtR4QubgJb4TzCQ==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -3894,13 +3894,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.1.0.tgz",
-      "integrity": "sha512-u9pCesRWb6mVtLnFLSfZ8R21TDz8YCebAxViefWsJlb0+p0yknesVL1nG/Oi9tgfhczS991HGIVsLT41bZthUw==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.1.1.tgz",
+      "integrity": "sha512-1Wqefy1W9Y63g48Fp7BscL95V4U1seDGgZawH6DcJnytJVW89hazao7YREzLYfdoediuw7lU+OHJksWYe4VQww==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.1.0",
-        "@angular-devkit/schematics": "17.1.0",
+        "@angular-devkit/core": "17.1.1",
+        "@angular-devkit/schematics": "17.1.1",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -4135,9 +4135,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.17.42",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.42.tgz",
+      "integrity": "sha512-ckM3jm2bf/MfB3+spLPWYPUH573plBFwpOhqQ2WottxYV85j1HQFlxmnTq57X1yHY9awZPig06hL/cLMgNWHIQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -16867,9 +16867,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.1.0"
+    "@angular/core": "^17.1.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.1.0",
+    "@angular-devkit/build-angular": "^17.1.1",
     "@angular-eslint/builder": "^17.2.1",
     "@angular-eslint/eslint-plugin": "^17.2.1",
     "@angular-eslint/eslint-plugin-template": "^17.2.1",
     "@angular-eslint/schematics": "^17.2.1",
     "@angular-eslint/template-parser": "^17.2.1",
-    "@angular/cli": "^17.1.0",
-    "@angular/common": "^17.1.0",
-    "@angular/compiler": "^17.1.0",
-    "@angular/compiler-cli": "^17.1.0",
-    "@angular/platform-browser": "^17.1.0",
-    "@angular/platform-browser-dynamic": "^17.1.0",
+    "@angular/cli": "^17.1.1",
+    "@angular/common": "^17.1.1",
+    "@angular/compiler": "^17.1.1",
+    "@angular/compiler-cli": "^17.1.1",
+    "@angular/platform-browser": "^17.1.1",
+    "@angular/platform-browser-dynamic": "^17.1.1",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.11.7",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.1.0 -> 17.1.1         ng update @angular/cli
      @angular/core                           17.1.0 -> 17.1.1         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>