### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.1.2",
+        "@angular-devkit/build-angular": "^17.1.3",
         "@angular-eslint/builder": "^17.2.1",
         "@angular-eslint/eslint-plugin": "^17.2.1",
         "@angular-eslint/eslint-plugin-template": "^17.2.1",
         "@angular-eslint/schematics": "^17.2.1",
         "@angular-eslint/template-parser": "^17.2.1",
-        "@angular/cli": "^17.1.2",
-        "@angular/common": "^17.1.2",
-        "@angular/compiler": "^17.1.2",
-        "@angular/compiler-cli": "^17.1.2",
-        "@angular/platform-browser": "^17.1.2",
-        "@angular/platform-browser-dynamic": "^17.1.2",
+        "@angular/cli": "^17.1.3",
+        "@angular/common": "^17.1.3",
+        "@angular/compiler": "^17.1.3",
+        "@angular/compiler-cli": "^17.1.3",
+        "@angular/platform-browser": "^17.1.3",
+        "@angular/platform-browser-dynamic": "^17.1.3",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.11.17",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.3"
       },
       "peerDependencies": {
-        "@angular/core": "^17.1.2"
+        "@angular/core": "^17.1.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1701.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1701.2.tgz",
-      "integrity": "sha512-g3gn5Ht6r9bCeFeAYF+HboZB8IvgvqqdeOnaWNaXJLI0ymEkpbqRdqrHGuVKHJV7JOMNXC7GPJEctBC6SXxOxA==",
+      "version": "0.1701.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1701.3.tgz",
+      "integrity": "sha512-K5rvhslbXNwx04cCLviEJCA27MwoJRMMzALFXySi9BqjZnZUOtZnOBuuCdrTPaRmFaYqGO4Im5GNzpbb/NB8zg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.1.2",
+        "@angular-devkit/core": "17.1.3",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.1.2.tgz",
-      "integrity": "sha512-QIDTP+TjiCKCYRZYb8to4ymvIV1Djcfd5c17VdgMGhRqIQAAK1V4f4A1njdhGYOrgsLajZQAnKvFfk2ZMeI37A==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.1.3.tgz",
+      "integrity": "sha512-pusFVSWMnrm2GrF3+Fw19OhA2rNw4WkfTMUruhaKAjW5QIvZ3wHYf+pH//1Ud+tuhFBi9BH7UALP2vnJMu1ehw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1701.2",
-        "@angular-devkit/build-webpack": "0.1701.2",
-        "@angular-devkit/core": "17.1.2",
+        "@angular-devkit/architect": "0.1701.3",
+        "@angular-devkit/build-webpack": "0.1701.3",
+        "@angular-devkit/core": "17.1.3",
         "@babel/core": "7.23.7",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.23.7",
         "@babel/runtime": "7.23.7",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.1.2",
+        "@ngtools/webpack": "17.1.3",
         "@vitejs/plugin-basic-ssl": "1.0.2",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.16",
@@ -291,12 +291,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1701.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1701.2.tgz",
-      "integrity": "sha512-LqfSO5iTbiYByDadUET/8uIun8vSHMEdtoxiil/kdZ5T0NG0p7K8QqUMnWgg6suwO6kFfYJkMiS8Dq3Y/ONUNQ==",
+      "version": "0.1701.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1701.3.tgz",
+      "integrity": "sha512-fpZtJf6yvXM7mX1T83caeYpa0e3zPv7sgKmx0ZIJKGL8+DETgNcCCeCTgui7HMBcHGCD8yj72DZ8xMMBWwVBIA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1701.2",
+        "@angular-devkit/architect": "0.1701.3",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.1.2.tgz",
-      "integrity": "sha512-ku+/W/HMCBacSWFppenr9y6Lx8mDuTuQvn1IkTyBLiJOpWnzgVbx9kHDeaDchGa1PwLlJUBBrv27t3qgJOIDPw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.1.3.tgz",
+      "integrity": "sha512-iuVK4hyW3YhusxIi8zGBvvVA9pWtDT3H6LQbWdVk9D3jXCZBIrEMklvAiJErqficKnUurf6gtFOeA8Fop6GotA==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -349,12 +349,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.1.2.tgz",
-      "integrity": "sha512-8S9RuM8olFN/gwN+mjbuF1CwHX61f0i59EGXz9tXLnKRUTjsRR+8vVMTAmX0dvVAT5fJTG/T69X+HX7FeumdqA==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.1.3.tgz",
+      "integrity": "sha512-zKoWG1hDfvi1vR9Hqoca9hWo9vDg8evmQvGcBW5jXR5ndZi5Oit/uDcGdA8WUKvBd1EG7WMqp0FgcDR9EA9WCw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.1.2",
+        "@angular-devkit/core": "17.1.3",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.5",
         "ora": "5.4.1",
@@ -490,15 +490,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.1.2.tgz",
-      "integrity": "sha512-U1W6XZNrfeRkXW2fO3AU25rRttqZahVkhzcK3lAtJ8+lSrStCOF7x1gz6tmFZFte1fNHQrXqD0yIDkd8H2/cvw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.1.3.tgz",
+      "integrity": "sha512-ysPWDdqo2cwfeskKVAg8p4C8xuezWcIWyW/ACSjWw6yp4OZvyVd6cGZrc0POVZzAPtTOYJSgWOpF/DCHQFluSg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1701.2",
-        "@angular-devkit/core": "17.1.2",
-        "@angular-devkit/schematics": "17.1.2",
-        "@schematics/angular": "17.1.2",
+        "@angular-devkit/architect": "0.1701.3",
+        "@angular-devkit/core": "17.1.3",
+        "@angular-devkit/schematics": "17.1.3",
+        "@schematics/angular": "17.1.3",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -539,9 +539,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.1.2.tgz",
-      "integrity": "sha512-y/wD+zuPaPgK3dB80Q63qBtuu5TuryKuUgjWrOmrguBWV9oiJRhKQrcp1gVw9vVrowmbDBKGtPMS622Q4oxOWQ==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.1.3.tgz",
+      "integrity": "sha512-AzLzoNSeRSNGBQk0K+iG0XdYG36SDeJqYqE8rfoiWuv1NDFLL05UJM2/fQfaMNg0oX5bHOlHUqHFj3sFR/NVpw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -550,14 +550,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.1.2",
+        "@angular/core": "17.1.3",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.1.2.tgz",
-      "integrity": "sha512-1vJuQRM5V01nC6qsLvBKrHVZXpzbK0YKubwVQUXCSfDNZBcDFak3SQcwU4C2t880rU3ZvFDB1UWfk7CKn5w9Kw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.1.3.tgz",
+      "integrity": "sha512-k/s21gPPKStxVOLr6l4Y145OIxyBY7BhTPVOl/qEAgE+IcZ9vkiA8dYl8yjL884Kl1ZKPmFA3AofMJjWjZGNag==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -566,7 +566,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.1.2"
+        "@angular/core": "17.1.3"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.1.2.tgz",
-      "integrity": "sha512-4P4ttCe4IF9yq7bxCDxbVW7purN7qV0nqofP5Tth1xCsgIJeGmOMMQJN5RJCZNrAPMkvMv39eV878sgcDjbpOA==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.1.3.tgz",
+      "integrity": "sha512-bNDHXo3Twub0BZK9OmXly+0REs0RuR1SUXlTAeq+0XubCvnBDvpg9peL7UTTGS5YRo9sUTBnR6faSUA1F5objQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -598,14 +598,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.1.2",
+        "@angular/compiler": "17.1.3",
         "typescript": ">=5.2 <5.4"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.1.2.tgz",
-      "integrity": "sha512-0M787BZVgYSVogHCUzo/dFrT56TgfQoEsOQngHMpyERJZv6dycXZlRdHc6TzvHUa+Uu/MNjn/RclBR8063bdWA==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.1.3.tgz",
+      "integrity": "sha512-2lZ4DRHN8KJ/aQads+YXIcx5Ri9yyeFIlw69m5Pn7wAi/+Rakg7IsclgLaWs7aBtWwMHG7LnqFKxAVq7CjXKtA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -619,9 +619,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.1.2.tgz",
-      "integrity": "sha512-unfpA5OLnqDmDb/oAQR2t2iROpOg02qwZayxyFg4MUZdDdnghPCfX77L2sr6oVVa7OJfKYFlmwmBXX1H3zjcXA==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.1.3.tgz",
+      "integrity": "sha512-onPCvdk9f/6OhOo2zP6nfGKpzLma1QIxpFqD3jymbmIJTcVMOOQDMYW3eLtY+uSX8ribcJ7GQcbDGIM4rliTFg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -630,9 +630,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.1.2",
-        "@angular/common": "17.1.2",
-        "@angular/core": "17.1.2"
+        "@angular/animations": "17.1.3",
+        "@angular/common": "17.1.3",
+        "@angular/core": "17.1.3"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.1.2.tgz",
-      "integrity": "sha512-xiWVDHbA+owDhKo5SAnzZtawA1ktGthlCl3YTI+vmkJpF6axkYOqR7YL+aEQX/y/5GSK+oR+03SgAnYcpOwKlQ==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.1.3.tgz",
+      "integrity": "sha512-0lFhcFJfDzCSSVe8l8OY+UgUiwUwcbxwpvLod3XWBpf1iEUlr5720FIMA3VJYwpW3Oj4Uey3nVm13EMtRqpqdA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -652,10 +652,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.1.2",
-        "@angular/compiler": "17.1.2",
-        "@angular/core": "17.1.2",
-        "@angular/platform-browser": "17.1.2"
+        "@angular/common": "17.1.3",
+        "@angular/compiler": "17.1.3",
+        "@angular/core": "17.1.3",
+        "@angular/platform-browser": "17.1.3"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.1.2.tgz",
-      "integrity": "sha512-MdNVSIp0x8AK26L+CxMTXH4weq2sNIp4C09RSdk7y6UkfBxMA3O0jTto9tW3ehkBaaGZ4dSiWkXA8L/ydMiQmA==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.1.3.tgz",
+      "integrity": "sha512-mszRSb7aMNKHnkh3Jrfo83KVOguX/cUamJJcGIYe9o7tnLGRIoMp4vP0fx6Og4J0/CGDRhSDG4IiJ29aOU7K8A==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -3894,13 +3894,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.1.2.tgz",
-      "integrity": "sha512-1GlH0POaN7hVDF1sAm90E5SvAqnKK+PbD1oKSpug9l+1AUQ3vOamyGhEAaO+IxUqvNdgqZexxd5o9MyySTT2Zw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.1.3.tgz",
+      "integrity": "sha512-hmeasOvzmniy6urtzUKhEqGO67iPuLX/dVtkF4nWp2NTtcEKlvcJobNDMc+CTlX4+ZMPVOvmhDMQqrlfekZ+NQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.1.2",
-        "@angular-devkit/schematics": "17.1.2",
+        "@angular-devkit/core": "17.1.3",
+        "@angular-devkit/schematics": "17.1.3",
         "jsonc-parser": "3.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.1.2"
+    "@angular/core": "^17.1.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.1.2",
+    "@angular-devkit/build-angular": "^17.1.3",
     "@angular-eslint/builder": "^17.2.1",
     "@angular-eslint/eslint-plugin": "^17.2.1",
     "@angular-eslint/eslint-plugin-template": "^17.2.1",
     "@angular-eslint/schematics": "^17.2.1",
     "@angular-eslint/template-parser": "^17.2.1",
-    "@angular/cli": "^17.1.2",
-    "@angular/common": "^17.1.2",
-    "@angular/compiler": "^17.1.2",
-    "@angular/compiler-cli": "^17.1.2",
-    "@angular/platform-browser": "^17.1.2",
-    "@angular/platform-browser-dynamic": "^17.1.2",
+    "@angular/cli": "^17.1.3",
+    "@angular/common": "^17.1.3",
+    "@angular/compiler": "^17.1.3",
+    "@angular/compiler-cli": "^17.1.3",
+    "@angular/platform-browser": "^17.1.3",
+    "@angular/platform-browser-dynamic": "^17.1.3",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.11.17",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.1.2 -> 17.1.3         ng update @angular/cli
      @angular/core                           17.1.2 -> 17.1.3         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>