### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.2.0",
+        "@angular-devkit/build-angular": "^17.2.1",
         "@angular-eslint/builder": "^17.2.1",
         "@angular-eslint/eslint-plugin": "^17.2.1",
         "@angular-eslint/eslint-plugin-template": "^17.2.1",
         "@angular-eslint/schematics": "^17.2.1",
         "@angular-eslint/template-parser": "^17.2.1",
-        "@angular/cli": "^17.2.0",
-        "@angular/common": "^17.2.1",
-        "@angular/compiler": "^17.2.1",
-        "@angular/compiler-cli": "^17.2.1",
-        "@angular/platform-browser": "^17.2.1",
-        "@angular/platform-browser-dynamic": "^17.2.1",
+        "@angular/cli": "^17.2.1",
+        "@angular/common": "^17.2.2",
+        "@angular/compiler": "^17.2.2",
+        "@angular/compiler-cli": "^17.2.2",
+        "@angular/platform-browser": "^17.2.2",
+        "@angular/platform-browser-dynamic": "^17.2.2",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.11.20",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.4"
       },
       "peerDependencies": {
-        "@angular/core": "^17.2.1"
+        "@angular/core": "^17.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1702.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1702.0.tgz",
-      "integrity": "sha512-+HkOYhdq8ez2+yqpxaQ6XtQevOYJNaDpM4oDmZ2lIpiIusFNsmpY2b9iL5PZGb4EfUgN8KsY3n9Q9fmRlRB9eA==",
+      "version": "0.1702.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1702.1.tgz",
+      "integrity": "sha512-eYYtR3kCG0V7aHsL34O4v8W2nW6MX4+SebhBO2dHGz2nCAS09LPtyO2fZZGawPgXOrN0nkLfghghI0hJ0dDaOw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.2.0",
+        "@angular-devkit/core": "17.2.1",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.2.0.tgz",
-      "integrity": "sha512-zO2YKcRRL3Ck3KZ3Ir/lWlciYIguJd3W9iYICKkeK4whi94y3NhrCy0Iualoo2WP7hE043uKQ0SwtVABft0SgA==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.2.1.tgz",
+      "integrity": "sha512-Wq3ggliCMQCRVCucbjE4/9BJCN1KMSGfF6Bx1ke2B+vW3ElLt+M4x4Eeyg2dSPEYB7slgY9WOx7qtyOkUy15tQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1702.0",
-        "@angular-devkit/build-webpack": "0.1702.0",
-        "@angular-devkit/core": "17.2.0",
+        "@angular-devkit/architect": "0.1702.1",
+        "@angular-devkit/build-webpack": "0.1702.1",
+        "@angular-devkit/core": "17.2.1",
         "@babel/core": "7.23.9",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.23.9",
         "@babel/runtime": "7.23.9",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.2.0",
+        "@ngtools/webpack": "17.2.1",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.17",
@@ -670,12 +670,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1702.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1702.0.tgz",
-      "integrity": "sha512-HrJ01MXlXNCeJeohIOIjpulWktUUJQpq01OWX4UazLnN0DAHKIFCwiKZZio5rYIFFUjdKI0+cCGxFbkzetRjWg==",
+      "version": "0.1702.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1702.1.tgz",
+      "integrity": "sha512-cmtGn8IYqruHuq1yPYEA17tLDTGmMhDPLagAbjZPVAjTpwCwC28H6sRXyhLTiSpzXdXUgROTO6bSXTvtJyyDSA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1702.0",
+        "@angular-devkit/architect": "0.1702.1",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -689,9 +689,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.2.0.tgz",
-      "integrity": "sha512-GIOYHChtDqSOvSiEefJ6hAledEl55J5Pxw8JuKXrM4IJBbviI3c40FAc0Lu5NCj2lYoELOhrLy/UP36sLy+DGA==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.2.1.tgz",
+      "integrity": "sha512-4jWG7akd5wVxjKkLKDT1zUTyLJeBP5mDmGUPooZ6zVHy39X6htYC+BV3uu/T6gVrD4FyONMDezedpBOrQPtZ6A==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -734,12 +734,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.2.0.tgz",
-      "integrity": "sha512-gGyUVYRKTeRODW9S0MohfBlryoUHrbxqN27olhktrM/fZavyUVnZpyfb8okp6tTUz9HWmGac8ULE6IU+YW16gw==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.2.1.tgz",
+      "integrity": "sha512-PgbjZgMSk1Q8QAH4mAx/dHDzPjNnXFONsNmwo80JPp6eJcBN0pODbchulFYdY7kPry07sNtGGWpQeWtdPAZHPw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.2.0",
+        "@angular-devkit/core": "17.2.1",
         "jsonc-parser": "3.2.1",
         "magic-string": "0.30.7",
         "ora": "5.4.1",
@@ -881,15 +881,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.2.0.tgz",
-      "integrity": "sha512-JSfNQB76qrc8QNPLUvvqR10T4+WUrfz+ogmOliO+jAdhbpfZQ4tIt0WwUYvo+0foM8x7hTe3Wdhg8zWwteBnuw==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.2.1.tgz",
+      "integrity": "sha512-zurPJunprq6ZRpNd6Icx7Ne819WN+pL7tQAlwTof7xuCnwfnIV32xiylFkvn77eyRN0Qh+so1FLlFy0t1jH4Mw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1702.0",
-        "@angular-devkit/core": "17.2.0",
-        "@angular-devkit/schematics": "17.2.0",
-        "@schematics/angular": "17.2.0",
+        "@angular-devkit/architect": "0.1702.1",
+        "@angular-devkit/core": "17.2.1",
+        "@angular-devkit/schematics": "17.2.1",
+        "@schematics/angular": "17.2.1",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -936,9 +936,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.2.1.tgz",
-      "integrity": "sha512-ZkQwvjJhnqKulJn3kwbnodYvQf8g8hy2FUMB2MRLXKgwLPv9iqF/KRgSwcNIZnq8hyvIr6FmAntMdyCOonykDQ==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.2.2.tgz",
+      "integrity": "sha512-F2wQj/lYcZUNZuNmuuDb8RK8tU7e1w7IzN8J6nT2gQHq6NiZfYiUL2XrToGtdd/cZjBeYKGiWRBW/PsZzKyC3A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -947,14 +947,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.2.1",
+        "@angular/core": "17.2.2",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.2.1.tgz",
-      "integrity": "sha512-jKk1ZQxZA/iGj0RsCa5rbd4gaygmfZcj7K1+VfGcY6NPyFkBGfFxIcA5fkZPOBvlNHjurXGuejA8NrsQ0kHbOw==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.2.2.tgz",
+      "integrity": "sha512-loRr4+9/JkSDszExZiS+iuhjXj7wvLF4gJeqlbp2PbPl4eUoGKYq0RVZ3a7IkIXxB5sgoYB5MjKsbdm/uaMK1A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -963,7 +963,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.2.1"
+        "@angular/core": "17.2.2"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.2.1.tgz",
-      "integrity": "sha512-7/1KgQOyjekVJxxLnGq+PcpbhIosK4yUaYDyUr33ehDYE5MoEGtyukNx6Sn/CPex4AcJ/978zKfSXHYY451S8w==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.2.2.tgz",
+      "integrity": "sha512-tFfbamdLhn8R30/aKxhXNG6CwelJOpVxfUnTizb7pWUJ/UQ4py0xzJp7s0QzKjR1lpRAq3rPtsE3f9BbcHD1HA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -995,14 +995,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.2.1",
+        "@angular/compiler": "17.2.2",
         "typescript": ">=5.2 <5.4"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.2.1.tgz",
-      "integrity": "sha512-gfWeskXA8RA0D3WOPBV5wT8RpqtqFhB8OCR8diGfLojqbMrmZXEvxALBHKAgfarWcR1rnRgmjCQKejWLWCLmmg==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.2.2.tgz",
+      "integrity": "sha512-jXnrOVsA9b34PJN383EOss3ejd5+xUTeijuUy5njPRXpxMxrGjV5gkk0lSxsALRxw2ICax2tMoGmHXfXO1x9gw==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.2.1.tgz",
-      "integrity": "sha512-on+fTZiDTBJmRQbQe6GOClqaUFe4GJdLS1EbmI+6/8Ntv4QW2PowWnaxajoqTj2Zrh22J9DSNy7RWcrQDdyU3g==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.2.2.tgz",
+      "integrity": "sha512-6AZhQfZpo/apiRKwhy6es1RpoxgCXMR4y7Eo7GvVHpMKBwioWwP2H+qg83ed2xv0/GXIyqZsHjpEjsLPE83uyw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1027,9 +1027,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.2.1",
-        "@angular/common": "17.2.1",
-        "@angular/core": "17.2.1"
+        "@angular/animations": "17.2.2",
+        "@angular/common": "17.2.2",
+        "@angular/core": "17.2.2"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1038,9 +1038,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.2.1.tgz",
-      "integrity": "sha512-J8mpB/LDMnPez1Xtaq/j4JEp7E1m7vVMfzJQvKPt1vZmp5EEzyo++u9k5yYKnGpfWTudBXHRIjK2mCjo7wNajg==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.2.2.tgz",
+      "integrity": "sha512-I52zbDSic4LB0yhCFUEBZKg9QkLKVUCGTco0XFHNRy3EF54Jvs0uWBqG79egsuXmyBNQY0E3op9eqhhn6Mnwbw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1049,10 +1049,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.2.1",
-        "@angular/compiler": "17.2.1",
-        "@angular/core": "17.2.1",
-        "@angular/platform-browser": "17.2.1"
+        "@angular/common": "17.2.2",
+        "@angular/compiler": "17.2.2",
+        "@angular/core": "17.2.2",
+        "@angular/platform-browser": "17.2.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3580,9 +3580,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.2.0.tgz",
-      "integrity": "sha512-3VilWAMylVpOqffhnLdc/UeElUWhBbG5j2XzxYWfQXb8OcVYoKNYPmJLc1vemoaYkkbaUX3zc5AEAN93Hk/q/g==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.2.1.tgz",
+      "integrity": "sha512-5O493oqZw0os1Gj3otVTcIXS3nGs60eXZ9w3vsK5w7tZ5x6XqZvO00X8WZQhcxXA9HMG4iDCsU2ll3lcYZVxmg==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4410,13 +4410,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.2.0.tgz",
-      "integrity": "sha512-k5SisAPTRXxP2WVjWHgQl2sQkaAkUiOZJrHhTmUghTowULN2eIiW+1SSdNBFCbv+qkl276NfavOi22j+C7uaKQ==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.2.1.tgz",
+      "integrity": "sha512-OUKupokfgmomWVysBpZ6CB7S3gzyjbVBb5L6UyhNLKAGRFxKOG5XWMPOo0ZdZjfuHB++HyRVj9Dh/rq0+PKHfA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.2.0",
-        "@angular-devkit/schematics": "17.2.0",
+        "@angular-devkit/core": "17.2.1",
+        "@angular-devkit/schematics": "17.2.1",
         "jsonc-parser": "3.2.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.2.1"
+    "@angular/core": "^17.2.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.2.0",
+    "@angular-devkit/build-angular": "^17.2.1",
     "@angular-eslint/builder": "^17.2.1",
     "@angular-eslint/eslint-plugin": "^17.2.1",
     "@angular-eslint/eslint-plugin-template": "^17.2.1",
     "@angular-eslint/schematics": "^17.2.1",
     "@angular-eslint/template-parser": "^17.2.1",
-    "@angular/cli": "^17.2.0",
-    "@angular/common": "^17.2.1",
-    "@angular/compiler": "^17.2.1",
-    "@angular/compiler-cli": "^17.2.1",
-    "@angular/platform-browser": "^17.2.1",
-    "@angular/platform-browser-dynamic": "^17.2.1",
+    "@angular/cli": "^17.2.1",
+    "@angular/common": "^17.2.2",
+    "@angular/compiler": "^17.2.2",
+    "@angular/compiler-cli": "^17.2.2",
+    "@angular/platform-browser": "^17.2.2",
+    "@angular/platform-browser-dynamic": "^17.2.2",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.11.20",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.2.0 -> 17.2.1         ng update @angular/cli
      @angular/core                           17.2.1 -> 17.2.2         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>