### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.3.0",
+        "@angular-devkit/build-angular": "^17.3.1",
         "@angular-eslint/builder": "^17.3.0",
         "@angular-eslint/eslint-plugin": "^17.3.0",
         "@angular-eslint/eslint-plugin-template": "^17.3.0",
         "@angular-eslint/schematics": "^17.3.0",
         "@angular-eslint/template-parser": "^17.3.0",
-        "@angular/cli": "^17.3.0",
-        "@angular/common": "^17.3.0",
-        "@angular/compiler": "^17.3.0",
-        "@angular/compiler-cli": "^17.3.0",
-        "@angular/platform-browser": "^17.3.0",
-        "@angular/platform-browser-dynamic": "^17.3.0",
+        "@angular/cli": "^17.3.1",
+        "@angular/common": "^17.3.1",
+        "@angular/compiler": "^17.3.1",
+        "@angular/compiler-cli": "^17.3.1",
+        "@angular/platform-browser": "^17.3.1",
+        "@angular/platform-browser-dynamic": "^17.3.1",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.11.30",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.4"
       },
       "peerDependencies": {
-        "@angular/core": "^17.3.0"
+        "@angular/core": "^17.3.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1703.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.0.tgz",
-      "integrity": "sha512-2X2cswI4TIwtQxCe5U9f4jeiDjAb8r89XLpU0QwEHyZyWx02uhYHO3FDMJq/NxCS95IUAQOBGBhbD4ey4Hl9cQ==",
+      "version": "0.1703.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.1.tgz",
+      "integrity": "sha512-vkfvURv7O+3fHMTE9K+yUEiFS0v4JNYKsDP0LE1ChH5Ocy0bJXGcH2Cyz2W8qdJGDG/tKe41VzvOLpu88Xv3zQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.0",
+        "@angular-devkit/core": "17.3.1",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.0.tgz",
-      "integrity": "sha512-mC70mZK/liITM4VlGL6hmYPkVsZwAb+X3TxwodBl/g8p/sYijDhK/4QJHzmcHTxLYQQS6nS5CUcr9ARQFkGN2w==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.1.tgz",
+      "integrity": "sha512-e+hZvLVH5AvHCFbVtKRd5oJeFsEmjg7kK1V6hsVxH4YE2f2x399TSr+AGxwV+R3jnjZ67ujIeXXd0Uuf1RwcSg==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1703.0",
-        "@angular-devkit/build-webpack": "0.1703.0",
-        "@angular-devkit/core": "17.3.0",
+        "@angular-devkit/architect": "0.1703.1",
+        "@angular-devkit/build-webpack": "0.1703.1",
+        "@angular-devkit/core": "17.3.1",
         "@babel/core": "7.24.0",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.24.0",
         "@babel/runtime": "7.24.0",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.3.0",
+        "@ngtools/webpack": "17.3.1",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.18",
@@ -715,12 +715,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1703.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.0.tgz",
-      "integrity": "sha512-IEaLzV5lolURJhMKM4naW6pYTDjI5E8I+97o/kbSa0yakvGOBwg7yRmfc54T1M0Z4nmifPsj4OVRGhBaa6dgXA==",
+      "version": "0.1703.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.1.tgz",
+      "integrity": "sha512-nVUzewX8RCzaEPQZ1JQpE42wpsYchKQwfXUSCkoUsuCMB2c6zuEz0Jt94nzJg3UjSEEV4ZqCH8v5MDOvB49Rlw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.0",
+        "@angular-devkit/architect": "0.1703.1",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.0.tgz",
-      "integrity": "sha512-ldErhMYq8rcFOhWQ0syQdLy6IYb/LL0erigj7gCMOf59oJgM7B13o/ZTOCvyJttUZ9IP0HB98Gi3epEuJ30VLg==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.1.tgz",
+      "integrity": "sha512-EP7zwqBEaOPuBJwzKmh2abfgNFITGX178BOyTG6zTymeMzEbrvy2OdeQXSslkJ/RGLCpx60GT+0CFW7wGlQR6Q==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -779,12 +779,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.0.tgz",
-      "integrity": "sha512-EW4Y8W/KTlvvT2fw3bh9hY7quDF2b9EaF+KftEqoDRWYbw0tlF8hWIdlfA6JxQC12d6uefh3kDNj5am0Il2oNQ==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.1.tgz",
+      "integrity": "sha512-c3tp5zC5zp6XpK9w8wJf3d4Dyw9BNbmg/VEoXtePGivp4hzks6zuMAFknNRwdK7roOlH0HyM5No4WUZHBFpOmw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.0",
+        "@angular-devkit/core": "17.3.1",
         "jsonc-parser": "3.2.1",
         "magic-string": "0.30.8",
         "ora": "5.4.1",
@@ -1430,15 +1430,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.0.tgz",
-      "integrity": "sha512-xwxlimNP4MECkdzjc0+m7lGxighcH0ncAfEo9yUo+r+4EFalB/Q7DAQPIU1xkbBk8iJwcFhGFAnS1IeLur15kQ==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.1.tgz",
+      "integrity": "sha512-IVnnbRi53BZvZ3LE0PCfFefoB2uHlO1sHtilZf/xCpdV4E1Mkz0/hHln5CRHwAXErdSiY57VoMsF5tffxAfaBQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.0",
-        "@angular-devkit/core": "17.3.0",
-        "@angular-devkit/schematics": "17.3.0",
-        "@schematics/angular": "17.3.0",
+        "@angular-devkit/architect": "0.1703.1",
+        "@angular-devkit/core": "17.3.1",
+        "@angular-devkit/schematics": "17.3.1",
+        "@schematics/angular": "17.3.1",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.2",
@@ -1485,9 +1485,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.0.tgz",
-      "integrity": "sha512-JnS6jbLl2RxsvGFUOBGeoyviNLEjZKRhn3uK4Ein3DENPv0BeSFMjif9Dp4ReUCnqoD4QQVG0X/r1GFaqHn2pw==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.1.tgz",
+      "integrity": "sha512-HyUTJ4RxhE3bOmFRV6Fv2y01ixbrUb8Hd4MxPm8REbNMGKsWCfXhR3FfxFL18Sc03SAF+o0Md0wwekjFKTNKfQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1496,14 +1496,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.0",
+        "@angular/core": "17.3.1",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.0.tgz",
-      "integrity": "sha512-lZBD5mFq7SzFJydZwW2jvnQGmtcU1s3e548hl4MSZpRgt13m5UmBQKbyMOvVN2WxKvWKlmDlywsAJlMSXepYig==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.1.tgz",
+      "integrity": "sha512-8qqlWPGZEyD2FY5losOW3Aocro+lFysPDzsf0LHgQUM6Ub1b+pq4jUOjH6w0vzaxG3TfxkgzOQ9aNdWtSV67Rg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1512,7 +1512,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.0"
+        "@angular/core": "17.3.1"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -1521,9 +1521,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.0.tgz",
-      "integrity": "sha512-ewo+pb0QUC69Ey15z4vPteoBeO81HitqplysOoeXbyVBjMnKmZl3343wx7ukgcI97lmj4d38d1r4AnIoO5n/Vw==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.1.tgz",
+      "integrity": "sha512-xLV9KU+zOpe57/2rQ59ku21EaStNpLSlR9+qkDYf8JR09fB+W9vY3UYbpi5RjHxAFIZBM5D9SFQjjll8rch26g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -1544,14 +1544,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.3.0",
+        "@angular/compiler": "17.3.1",
         "typescript": ">=5.2 <5.5"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.0.tgz",
-      "integrity": "sha512-umwsNFl/wEMTCUVvNl5iieEgHA+ESxSMcjedZGFWNGnpUxKTgYFYNG41/1wNZfPrS0+uRPHuYU9IHD+NR2s/Rw==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.1.tgz",
+      "integrity": "sha512-Qf3/sgkXS1LHwOTtqAVYprySrn0YpPIZqerPc0tK+hyQfwAz5BQlpcBhbH8RWKlfCY8eO0cqo/j0+e8DQOgYfg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1565,9 +1565,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.0.tgz",
-      "integrity": "sha512-sIquvbq04KMOdpk1VdVFt7kVhOk/Rk+hI3M4raarMK5EbZ16nLYzpqjc2OZetUpKy6LB/FemClgNUShj9NlrqA==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.1.tgz",
+      "integrity": "sha512-8ABAL8PElSGzkIparVwifsU0NSu0DdqnWYw9YvLhhZQ6lOuWbG+dTUo/DXzmWhA6ezQWJGNakEZPJJytFIIy+A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1576,9 +1576,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.3.0",
-        "@angular/common": "17.3.0",
-        "@angular/core": "17.3.0"
+        "@angular/animations": "17.3.1",
+        "@angular/common": "17.3.1",
+        "@angular/core": "17.3.1"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.0.tgz",
-      "integrity": "sha512-oX5AG0aSjmB89SyJZGyabr6uwfWd7yJM+krcrzHxFbVhvDCwdi9G+B0ADmaUn1shaXDseOFiLpo3R/oagd2fTA==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.1.tgz",
+      "integrity": "sha512-ACW/npNaDxUNQtEomjjv/KIBY8jHEinePff5qosnAxLE0IpA4qE9eDp36zG35xoJqrPJPYjXbZCBRqqrzM7U7Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1598,10 +1598,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.0",
-        "@angular/compiler": "17.3.0",
-        "@angular/core": "17.3.0",
-        "@angular/platform-browser": "17.3.0"
+        "@angular/common": "17.3.1",
+        "@angular/compiler": "17.3.1",
+        "@angular/core": "17.3.1",
+        "@angular/platform-browser": "17.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4121,9 +4121,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.0.tgz",
-      "integrity": "sha512-wNTCDPPEtjP4mxYerLVLCMwOCTEOD2HqZMVXD8pJbarrGPMuoyglUZuqNSIS5KVqR+fFez6JEUnMvC3QSqf58w==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.1.tgz",
+      "integrity": "sha512-6qRYFN6DqogZK0ZFrSlhg1OsIWm3lL3m+/Ixoj6/MLLjDBrTtHqmI93vg6P1EKYTH4fWChL7jtv7iS/LSZubgw==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4951,13 +4951,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.0.tgz",
-      "integrity": "sha512-QqugP4Uyxk966VaUb/Jk5LQ5rE1BV4v2TmniPZtN3GZ6MDkpvPnFvlysvoq6y+7uiRhCLiT1DsBIwc9vXz3vWA==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.1.tgz",
+      "integrity": "sha512-B3TkpjDjZhxX+tUc2ySEHU33x82Da0sssq/EMqQ1PQBHeRMa0ecyCeExjFEs2y57ZuC+QeVTaUt+TW45lLSjQw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.0",
-        "@angular-devkit/schematics": "17.3.0",
+        "@angular-devkit/core": "17.3.1",
+        "@angular-devkit/schematics": "17.3.1",
         "jsonc-parser": "3.2.1"
       },
       "engines": {
@@ -5287,9 +5287,9 @@
       "peer": true
     },
     "node_modules/@types/qs": {
-      "version": "6.9.12",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.12.tgz",
-      "integrity": "sha512-bZcOkJ6uWrL0Qb2NAWKa7TBU+mJHPzhx9jjLL1KHF+XpzEcR7EXHvjbHlGtR/IsP1vyPrehuS6XqkmaePy//mg==",
+      "version": "6.9.14",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
+      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
@@ -9990,9 +9990,9 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.1.tgz",
+      "integrity": "sha512-K4w1/Bp7y8iSiVObmCrtq8Cs79XjJc/RU2YYkZQ7wpUu5ZyZ7MtPHkqoMz4pf+mgXfNvo2qft8D9OnrH2ABk9w==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -10000,7 +10000,7 @@
         "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -10032,9 +10032,9 @@
       }
     },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.3.0"
+    "@angular/core": "^17.3.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.3.0",
+    "@angular-devkit/build-angular": "^17.3.1",
     "@angular-eslint/builder": "^17.3.0",
     "@angular-eslint/eslint-plugin": "^17.3.0",
     "@angular-eslint/eslint-plugin-template": "^17.3.0",
     "@angular-eslint/schematics": "^17.3.0",
     "@angular-eslint/template-parser": "^17.3.0",
-    "@angular/cli": "^17.3.0",
-    "@angular/common": "^17.3.0",
-    "@angular/compiler": "^17.3.0",
-    "@angular/compiler-cli": "^17.3.0",
-    "@angular/platform-browser": "^17.3.0",
-    "@angular/platform-browser-dynamic": "^17.3.0",
+    "@angular/cli": "^17.3.1",
+    "@angular/common": "^17.3.1",
+    "@angular/compiler": "^17.3.1",
+    "@angular/compiler-cli": "^17.3.1",
+    "@angular/platform-browser": "^17.3.1",
+    "@angular/platform-browser-dynamic": "^17.3.1",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.11.30",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.3.0 -> 17.3.1         ng update @angular/cli
      @angular/core                           17.3.0 -> 17.3.1         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>