### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.3.3",
+        "@angular-devkit/build-angular": "^17.3.4",
         "@angular-eslint/builder": "^17.3.0",
         "@angular-eslint/eslint-plugin": "^17.3.0",
         "@angular-eslint/eslint-plugin-template": "^17.3.0",
         "@angular-eslint/schematics": "^17.3.0",
         "@angular-eslint/template-parser": "^17.3.0",
-        "@angular/cli": "^17.3.3",
-        "@angular/common": "^17.3.3",
-        "@angular/compiler": "^17.3.3",
-        "@angular/compiler-cli": "^17.3.3",
-        "@angular/platform-browser": "^17.3.3",
-        "@angular/platform-browser-dynamic": "^17.3.3",
+        "@angular/cli": "^17.3.4",
+        "@angular/common": "^17.3.4",
+        "@angular/compiler": "^17.3.4",
+        "@angular/compiler-cli": "^17.3.4",
+        "@angular/platform-browser": "^17.3.4",
+        "@angular/platform-browser-dynamic": "^17.3.4",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.12.4",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.4"
       },
       "peerDependencies": {
-        "@angular/core": "^17.3.3"
+        "@angular/core": "^17.3.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.3.tgz",
-      "integrity": "sha512-BKbdigCjmspqxOxSIQuWgPZzpyuKqZoTBDh0jDeLcAmvPsuxCgIWbsExI4OQ0CyusnQ+XT0IT39q8B9rvF56cg==",
+      "version": "0.1703.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.4.tgz",
+      "integrity": "sha512-o+XCMOiMh8tmQGEwcxjAj2/lmUVT7CGSUAM31ydDomVOFFw4CnBvsoyKqQNRC+/AUXvovb2dCegQl/lTAnrwOg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.4",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.3.tgz",
-      "integrity": "sha512-E/6Z1MIMhEB1I2sN+Pw4/zinwAFj4vLDh6dEuj856WWEPndgPiUB6fGX4EbCTsyIUzboXI5ysdNyt2Eq56bllA==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.4.tgz",
+      "integrity": "sha512-8KieoPrsJcFPoza0gLQ6yebtIb3WdH3j/V1TnAihk4tVpgtdch8tOBE3FP1TnSW3RF+iCsA0I5NO9/4YbEsWtw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/build-webpack": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/architect": "0.1703.4",
+        "@angular-devkit/build-webpack": "0.1703.4",
+        "@angular-devkit/core": "17.3.4",
         "@babel/core": "7.24.0",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.24.0",
         "@babel/runtime": "7.24.0",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.3.3",
+        "@ngtools/webpack": "17.3.4",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.18",
@@ -149,8 +149,8 @@
         "terser": "5.29.1",
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
-        "undici": "6.7.1",
-        "vite": "5.1.5",
+        "undici": "6.11.1",
+        "vite": "5.1.7",
         "watchpack": "2.4.0",
         "webpack": "5.90.3",
         "webpack-dev-middleware": "6.1.2",
@@ -715,12 +715,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.3.tgz",
-      "integrity": "sha512-d0JjE8MaGVNphlJfeP1OZKhNT4wCXkEZKdSdwE0+W+vDHNUuZiUBB1czO48sb7T4xBrdjRWlV/9CzMNJ7n3ydA==",
+      "version": "0.1703.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.4.tgz",
+      "integrity": "sha512-9Vsl6rfIH8kF02W7i3tW/aMOT2Ld1zpcok7n7JdL3Pb7oW0SOjt73FN6Ykm/hVig12gsOGJtEsDfQRsnCddmfQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
+        "@angular-devkit/architect": "0.1703.4",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-J22Sh3M7rj8Ar3iEs20ko5wgC3DE7vWfYZNdimt2IJiS4J7BEX8R3Awf+TRt+6AN3NFm3/xe1Sz4yvDh3FvNFg==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.4.tgz",
+      "integrity": "sha512-vE69/Db555NTRPh+LUFO3rAQBbv7QGrK59F7chRggDZKamtCq/FfhEg2O+0BXQnUitOQN6WgQ79+payFYWyCCg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -779,12 +779,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.3.tgz",
-      "integrity": "sha512-SABqTtj2im4PJhQjNaAsSypbNkpZFW8YozJ3P748tlh5a9XoHpgiqXv5JhRbyKElLDAyk5i9fe2++JmSudPG/Q==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.4.tgz",
+      "integrity": "sha512-Z6801QhIwrMTcKPzdo9si+ZtJkPz8fys0ftOTfTM66+tDECasU7pvk8Dr54WkDY29mdSHzPxpSxAsooEwfxvQQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.4",
         "jsonc-parser": "3.2.1",
         "magic-string": "0.30.8",
         "ora": "5.4.1",
@@ -1430,15 +1430,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.3.tgz",
-      "integrity": "sha512-veIGK2sRm0SfiLHeftx0W0xC3N8uxoqxXiSG57V6W2wIFN/fKm3aRq3sa8phz7vxUzoKGqyZh6hsT7ybkjgkGA==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.4.tgz",
+      "integrity": "sha512-o4oIA2stUwXOur/T/kP3Zr8ZUCB4VYmvjACbsQ3tpzVCFYPeaW9psQagBNJfaBVVDSYL+EacVYBYJR9ZImvcGw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
-        "@schematics/angular": "17.3.3",
+        "@angular-devkit/architect": "0.1703.4",
+        "@angular-devkit/core": "17.3.4",
+        "@angular-devkit/schematics": "17.3.4",
+        "@schematics/angular": "17.3.4",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.2",
@@ -1485,9 +1485,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.3.tgz",
-      "integrity": "sha512-GwlKetNpfWKiG2j4S6bYTi6PA2iT4+eln7o8owo44xZWdQnWQjfxnH39vQuCyhi6OOQL1dozmae+fVXgQsV6jQ==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.4.tgz",
+      "integrity": "sha512-rEsmtwUMJaNvaimh9hwaHdDLXaOIrjEnYdhmJUvDaKPQaFfSbH3CGGVz9brUyzVJyiWJYkYM0ssxavczeiEe8g==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1496,14 +1496,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3",
+        "@angular/core": "17.3.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.3.tgz",
-      "integrity": "sha512-ZNMRfagMxMjk1KW5H3ssCg5QL0J6ZW1JAZ1mrTXixqS7gbdwl60bTGE+EfuEwbjvovEYaj4l9cga47eMaxZTbQ==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.4.tgz",
+      "integrity": "sha512-YrDClIzgj6nQwiYHrfV6AkT1C5LCDgJh+LICus/2EY1w80j1Qf48Zh4asictReePdVE2Tarq6dnpDh4RW6LenQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1512,7 +1512,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3"
+        "@angular/core": "17.3.4"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -1521,9 +1521,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.3.tgz",
-      "integrity": "sha512-vM0lqwuXQZ912HbLnIuvUblvIz2WEUsU7a5Z2ieNey6famH4zxPH12vCbVwXgicB6GLHorhOfcWC5443wD2mJw==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.4.tgz",
+      "integrity": "sha512-TVWjpZSI/GIXTYsmVgEKYjBckcW8Aj62DcxLNehRFR+c7UB95OY3ZFjU8U4jL0XvWPgTkkVWQVq+P6N4KCBsyw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -1544,14 +1544,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.3.3",
+        "@angular/compiler": "17.3.4",
         "typescript": ">=5.2 <5.5"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-O/jr3aFJMCxF6Jmymjx4jIigRHJfqM/ALIi60y2LVznBVFkk9xyMTsAjgWQIEHX+2muEIzgfKuXzpL0y30y+wA==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.4.tgz",
+      "integrity": "sha512-fvhBkfa/DDBzp1UcNzSxHj+Z9DebSS/o9pZpZlbu/0uEiu9hScmScnhaty5E0EbutzHB0SVUCz7zZuDeAywvWg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1565,9 +1565,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.3.tgz",
-      "integrity": "sha512-XFWjquD+Pr9VszRzrDlT6uaf57TsY9XhL9iHCNok6Op5DpVQpIAuw1vFt2t5ZoQ0gv+lY8mVWnxgqe3CgTdYxw==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.4.tgz",
+      "integrity": "sha512-W2nH9WSQJfdNG4HH9B1Cvj5CTmy9gF3321I+65Tnb8jFmpeljYDBC/VVUhTZUCRpg8udMWeMHEQHuSb8CbozmQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1576,9 +1576,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.3.3",
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3"
+        "@angular/animations": "17.3.4",
+        "@angular/common": "17.3.4",
+        "@angular/core": "17.3.4"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.3.tgz",
-      "integrity": "sha512-jSgSNHRTXCIat20I+4tLm/e8qOvrIE3Zv7S/DtYZEiAth84uoznvo1kXnN+KREse2vP/WoNgSDKQ2JLzkwYXSQ==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.4.tgz",
+      "integrity": "sha512-S53jPyQtInVYkjdGEFt4dxM1NrHNkWCvXGRsCO7Uh+laDf1OpIDp9YHf49OZohYLajJradN6y4QfdZL6IUwXKA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1598,10 +1598,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.3",
-        "@angular/compiler": "17.3.3",
-        "@angular/core": "17.3.3",
-        "@angular/platform-browser": "17.3.3"
+        "@angular/common": "17.3.4",
+        "@angular/compiler": "17.3.4",
+        "@angular/core": "17.3.4",
+        "@angular/platform-browser": "17.3.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4121,9 +4121,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.3.tgz",
-      "integrity": "sha512-053KMbg1Tb+Mmg4Htsv8yTpI7ABghguoxhwosQXKB0CjO6M0oexuvdaxbRDQ1vd5xYNOW9LcOfxOMPIwyU4BBA==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.4.tgz",
+      "integrity": "sha512-3uNX4tRTKPm91mSQcnmQtqDMMKLGDevJERSPJU7hlOXZZ05QrT4et1mwvXNYYMpXqi2OkC7D4ryIS2YxAiItBA==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4951,13 +4951,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.3.tgz",
-      "integrity": "sha512-kNlyjIKTBhfi8Jab3MCkxNRbbpErbzdu0lZNSL8Nidmqs6Tk23Dc1bZe4t/gPNOCkCvQlwYa6X88SjC/ntyVng==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.4.tgz",
+      "integrity": "sha512-Rqhp5l76Ej6BOZCHPrvHlA2SBkjv1aHFWAfW9gREke826j46D+fuA0eDAdgeVTz0Fx9e7XM3LdtWsz7CBlV4Ug==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
+        "@angular-devkit/core": "17.3.4",
+        "@angular-devkit/schematics": "17.3.4",
         "jsonc-parser": "3.2.1"
       },
       "engines": {
@@ -17882,9 +17882,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.7.1.tgz",
-      "integrity": "sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.11.1.tgz",
+      "integrity": "sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==",
       "dev": true,
       "engines": {
         "node": ">=18.0"
@@ -18087,9 +18087,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
-      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.7.tgz",
+      "integrity": "sha512-sgnEEFTZYMui/sTlH1/XEnVNHMujOahPLGMxn1+5sIT45Xjng1Ec1K78jRP15dSmVgg5WBin9yO81j3o9OxofA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.3.3"
+    "@angular/core": "^17.3.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.3.3",
+    "@angular-devkit/build-angular": "^17.3.4",
     "@angular-eslint/builder": "^17.3.0",
     "@angular-eslint/eslint-plugin": "^17.3.0",
     "@angular-eslint/eslint-plugin-template": "^17.3.0",
     "@angular-eslint/schematics": "^17.3.0",
     "@angular-eslint/template-parser": "^17.3.0",
-    "@angular/cli": "^17.3.3",
-    "@angular/common": "^17.3.3",
-    "@angular/compiler": "^17.3.3",
-    "@angular/compiler-cli": "^17.3.3",
-    "@angular/platform-browser": "^17.3.3",
-    "@angular/platform-browser-dynamic": "^17.3.3",
+    "@angular/cli": "^17.3.4",
+    "@angular/common": "^17.3.4",
+    "@angular/compiler": "^17.3.4",
+    "@angular/compiler-cli": "^17.3.4",
+    "@angular/platform-browser": "^17.3.4",
+    "@angular/platform-browser-dynamic": "^17.3.4",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.12.4",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.3.3 -> 17.3.4         ng update @angular/cli
      @angular/core                           17.3.3 -> 17.3.4         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>