### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.3.5",
+        "@angular-devkit/build-angular": "^17.3.6",
         "@angular-eslint/builder": "^17.3.0",
         "@angular-eslint/eslint-plugin": "^17.3.0",
         "@angular-eslint/eslint-plugin-template": "^17.3.0",
         "@angular-eslint/schematics": "^17.3.0",
         "@angular-eslint/template-parser": "^17.3.0",
-        "@angular/cli": "^17.3.5",
-        "@angular/common": "^17.3.5",
-        "@angular/compiler": "^17.3.5",
-        "@angular/compiler-cli": "^17.3.5",
-        "@angular/platform-browser": "^17.3.5",
-        "@angular/platform-browser-dynamic": "^17.3.5",
+        "@angular/cli": "^17.3.6",
+        "@angular/common": "^17.3.6",
+        "@angular/compiler": "^17.3.6",
+        "@angular/compiler-cli": "^17.3.6",
+        "@angular/platform-browser": "^17.3.6",
+        "@angular/platform-browser-dynamic": "^17.3.6",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.12.4",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.4"
       },
       "peerDependencies": {
-        "@angular/core": "^17.3.5"
+        "@angular/core": "^17.3.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -74,12 +74,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1703.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.5.tgz",
-      "integrity": "sha512-j3+9QeXIafuRMtk7N5Cmm/IiMSS/TOaybzfCv/LK+DP3hjEd8f8Az7hPmevUuOArvWNzUvoUeu30GmR3wABydA==",
+      "version": "0.1703.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.6.tgz",
+      "integrity": "sha512-Ck501FD/QuOjeKVFs7hU92w8+Ffetv0d5Sq09XY2/uygo5c/thMzp9nkevaIWBxUSeU5RqYZizDrhFVgYzbbOw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/core": "17.3.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -89,15 +89,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.5.tgz",
-      "integrity": "sha512-Ju2MkMidJglJq/iWgM9CNbhK7A/2n0LNYPZx+ucb+aOFWvurCQrU4Mt/es6xCsxOEs5OPhjqdva8mxE5FHwzTQ==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.6.tgz",
+      "integrity": "sha512-K4CEZvhQZUUOpmXPVoI1YBM8BARbIlqE6FZRxakmnr+YOtVTYE5s+Dr1wgja8hZIohNz6L7j167G9Aut7oPU/w==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1703.5",
-        "@angular-devkit/build-webpack": "0.1703.5",
-        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/architect": "0.1703.6",
+        "@angular-devkit/build-webpack": "0.1703.6",
+        "@angular-devkit/core": "17.3.6",
         "@babel/core": "7.24.0",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -108,7 +108,7 @@
         "@babel/preset-env": "7.24.0",
         "@babel/runtime": "7.24.0",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.3.5",
+        "@ngtools/webpack": "17.3.6",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.18",
@@ -715,12 +715,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1703.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.5.tgz",
-      "integrity": "sha512-KcoKlWhDP6+2q3laQ6elXLt2QrVxWJFdCPUC9dIm0Tnc997Tal/UVhlDKaZgITYDgDvRFqG+tzNm2uFd8l7h+A==",
+      "version": "0.1703.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.6.tgz",
+      "integrity": "sha512-pJu0et2SiF0kfXenHSTtAART0omzbWpLgBfeUo4hBh4uwX5IaT+mRpYpr8gCXMq+qsjoQp3HobSU3lPDeBn+bg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.5",
+        "@angular-devkit/architect": "0.1703.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.5.tgz",
-      "integrity": "sha512-iqGv45HVI+yRROoTqQTY0QChYlRCZkFUfIjdfJLegjc6xq9sLtxDr03CWM45BKGG5lSxDOy+qu/pdRvtL3V2eg==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.6.tgz",
+      "integrity": "sha512-FVbkT9dEwHEvjnxr4mvMNSMg2bCFoGoP4X68xXU9dhLEUpC05opLvfbaR3Qh543eCJ5AstosBFVzB/krfIkOvA==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -779,12 +779,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.5.tgz",
-      "integrity": "sha512-oh/mvpMKxGfk5v9QIB7LfGsDC/iVpmsIAvbb4+1ddCx86EJXdz3xWnVDbUehOd6n7HJXnQrNirWjWvWquM2GhQ==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.6.tgz",
+      "integrity": "sha512-2G1YuPInd8znG7uUgKOS7z72Aku50lTzB/2csWkWPJLAFkh7vKC8QZ40x8S1nC9npVYPhI5CRLX/HVpBh9CyxA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/core": "17.3.6",
         "jsonc-parser": "3.2.1",
         "magic-string": "0.30.8",
         "ora": "5.4.1",
@@ -1430,15 +1430,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.5.tgz",
-      "integrity": "sha512-6MHJzPKy4uB9qlJO1eKs4rtDlRuCe0lOiz1f3kHFZ/GQQm5xA1xsmZJMN4ASsnu4yU3oZs6vJ/vt8i2/jvdPbA==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.6.tgz",
+      "integrity": "sha512-poKaRPeI+hFqX+AxIaEriaIggFVcC3XqlT9E1/uBC2rfHirE1n5F9Z7xqEDtMHduKwLbNXhQIPoKIKya8+Hnew==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.5",
-        "@angular-devkit/core": "17.3.5",
-        "@angular-devkit/schematics": "17.3.5",
-        "@schematics/angular": "17.3.5",
+        "@angular-devkit/architect": "0.1703.6",
+        "@angular-devkit/core": "17.3.6",
+        "@angular-devkit/schematics": "17.3.6",
+        "@schematics/angular": "17.3.6",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.2",
@@ -1485,9 +1485,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.5.tgz",
-      "integrity": "sha512-Ox91WxSnOSrQ6I21cHi69EfT2Pxtd5Knb5AsdwpxqE57V2E7EnWMhb+LP+holCtFUhK529EGXCk788M+Elyw6g==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.6.tgz",
+      "integrity": "sha512-ufviCFzQQKWcwc2j3Zi8bHbwkvqh4QU6GDH0u0usOee8xd8KrjgcYl3vD0r1/yxlDsd53Wg9kNRvz/fY+5qQoQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1496,14 +1496,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.5",
+        "@angular/core": "17.3.6",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.5.tgz",
-      "integrity": "sha512-lTubBFNlpH9zK46+yeVI7VJQNUELLAB8W1ucndYLCA9Rr9Jop+rYIXijmr42AGokOYr7yLc8HRiSQ5e+X2pUQg==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.6.tgz",
+      "integrity": "sha512-ybx9O76RGv4J97IThiSVvvWukuGcuXu50KsBDPUd874BFT3ml0OcRGhXoMh/isz7EQipiiGgsA51cJVTLES5Zw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1512,7 +1512,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.5"
+        "@angular/core": "17.3.6"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -1521,9 +1521,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.5.tgz",
-      "integrity": "sha512-R53JNbbVDHWSGdL0e2vGQ5iJCrILOWZ1oemKjekOFB93fUBlEyi+nZmm4uTO7RU8PgjB0UpxI6ok5ZE3Amkt6A==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.6.tgz",
+      "integrity": "sha512-LaoUkY6uzcNocIEHJBvexvuU0a333IRQaG3Sj5IXhM1t864wTsfycn6yWJcQ7PhklB8BtNqiMbUQuEFtkxT8pg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -1544,14 +1544,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.3.5",
+        "@angular/compiler": "17.3.6",
         "typescript": ">=5.2 <5.5"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.5.tgz",
-      "integrity": "sha512-y6P27lcrKy3yMx/rtMuGsAnDyVEsS3BdyArTXcD0TOImVGHhVIaB0L95DUCam3ajTe2f2x39eozJZDh7QSpJaw==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.6.tgz",
+      "integrity": "sha512-8IoeZVNqyeHA+H2dR3VFfz76/TFN1BpXP0aABs2aIUNVQRYlKxALSm1UlavijX8IT0uvd/6GXwE3WgymTcg0wg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1565,9 +1565,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.5.tgz",
-      "integrity": "sha512-ITlu/GTD64Sr0FMaFCJiHoTJrEZw8qRFXjPjv3BKhAp5dQKcwnCm02o1NOaj5d8oIItIh5fbI2zP0CSU2qNZkQ==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.6.tgz",
+      "integrity": "sha512-UikrgvMwtZIXp2pCP5AtkM7ibz2B5wBiGpnhhkYsqHKy9ndKVDA+3B5Z+/j9xeYYdsJAAtHl45zqILewyg+4iw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1576,9 +1576,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.3.5",
-        "@angular/common": "17.3.5",
-        "@angular/core": "17.3.5"
+        "@angular/animations": "17.3.6",
+        "@angular/common": "17.3.6",
+        "@angular/core": "17.3.6"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.5.tgz",
-      "integrity": "sha512-KuS4j3Gh1h/CEj+bIOc/IcZIdiCB/DNbtUvz1eNp1o23aM8QutqelI3A4WBnQuR4yq8Z/8M3FH9F1OVwwhn2QQ==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.6.tgz",
+      "integrity": "sha512-dI+mgEROmSll042+XqkSsvkMQe6Et6L9BBiYYe7VbIFaRR9Dz5Pw2SeBLb+Ou+gWaxXc2Wc+13n442WEYWZ7Ew==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1598,10 +1598,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.5",
-        "@angular/compiler": "17.3.5",
-        "@angular/core": "17.3.5",
-        "@angular/platform-browser": "17.3.5"
+        "@angular/common": "17.3.6",
+        "@angular/compiler": "17.3.6",
+        "@angular/core": "17.3.6",
+        "@angular/platform-browser": "17.3.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4121,9 +4121,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.5.tgz",
-      "integrity": "sha512-0heI0yHUckdGI8uywu/wkp24KR/tdYMKYJOaYIU+9JydyN1zJRpbR7x0thddl7+k/zu2ZGbfFdv1779Ecw/xdA==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.6.tgz",
+      "integrity": "sha512-equxbgh2DKzZtiFMoVf1KD4yJcH1q8lpqQ/GSPPQUvONcmHrr+yqdRUdaJ7oZCyCYmXF/nByBxtMKtJr6nKZVg==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4951,13 +4951,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.5.tgz",
-      "integrity": "sha512-SWCK16Eob0K86hpZ3NHmrTS6LSzTlhvnIdf3BXC6nzoiyDhcAS0oJ2Tjdq1opW/PaL1hB7MulcbIhxYln5du0w==",
+      "version": "17.3.6",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.6.tgz",
+      "integrity": "sha512-jCNZdjHSVrI8TrrCnCoXC8GYvQRj7zh+SDdmm91Ve8dbikYNmBOKYLuPaCTsmojWx7ytv962yLlgKzpaa2bbfw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.5",
-        "@angular-devkit/schematics": "17.3.5",
+        "@angular-devkit/core": "17.3.6",
+        "@angular-devkit/schematics": "17.3.6",
         "jsonc-parser": "3.2.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.3.5"
+    "@angular/core": "^17.3.6"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.3.5",
+    "@angular-devkit/build-angular": "^17.3.6",
     "@angular-eslint/builder": "^17.3.0",
     "@angular-eslint/eslint-plugin": "^17.3.0",
     "@angular-eslint/eslint-plugin-template": "^17.3.0",
     "@angular-eslint/schematics": "^17.3.0",
     "@angular-eslint/template-parser": "^17.3.0",
-    "@angular/cli": "^17.3.5",
-    "@angular/common": "^17.3.5",
-    "@angular/compiler": "^17.3.5",
-    "@angular/compiler-cli": "^17.3.5",
-    "@angular/platform-browser": "^17.3.5",
-    "@angular/platform-browser-dynamic": "^17.3.5",
+    "@angular/cli": "^17.3.6",
+    "@angular/common": "^17.3.6",
+    "@angular/compiler": "^17.3.6",
+    "@angular/compiler-cli": "^17.3.6",
+    "@angular/platform-browser": "^17.3.6",
+    "@angular/platform-browser-dynamic": "^17.3.6",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.12.4",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            17.3.5 -> 17.3.6         ng update @angular/cli
      @angular/core                           17.3.5 -> 17.3.6         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>