### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "@angular-eslint/schematics": "^17.3.0",
         "@angular-eslint/template-parser": "^17.3.0",
         "@angular/cli": "^17.3.6",
-        "@angular/common": "^17.3.6",
-        "@angular/compiler": "^17.3.6",
-        "@angular/compiler-cli": "^17.3.6",
-        "@angular/platform-browser": "^17.3.6",
-        "@angular/platform-browser-dynamic": "^17.3.6",
+        "@angular/common": "^17.3.7",
+        "@angular/compiler": "^17.3.7",
+        "@angular/compiler-cli": "^17.3.7",
+        "@angular/platform-browser": "^17.3.7",
+        "@angular/platform-browser-dynamic": "^17.3.7",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.12.4",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.4"
       },
       "peerDependencies": {
-        "@angular/core": "^17.3.6"
+        "@angular/core": "^17.3.7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1485,9 +1485,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.3.6",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.6.tgz",
-      "integrity": "sha512-ufviCFzQQKWcwc2j3Zi8bHbwkvqh4QU6GDH0u0usOee8xd8KrjgcYl3vD0r1/yxlDsd53Wg9kNRvz/fY+5qQoQ==",
+      "version": "17.3.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.7.tgz",
+      "integrity": "sha512-A7LRJu1vVCGGgrfZXjU+njz50SiU4weheKCar5PIUprcdIofS1IrHAJDqYh+kwXxkjXbZMOr/ijQY0+AESLEsw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1496,14 +1496,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.6",
+        "@angular/core": "17.3.7",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.3.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.6.tgz",
-      "integrity": "sha512-ybx9O76RGv4J97IThiSVvvWukuGcuXu50KsBDPUd874BFT3ml0OcRGhXoMh/isz7EQipiiGgsA51cJVTLES5Zw==",
+      "version": "17.3.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.7.tgz",
+      "integrity": "sha512-AlKiqPoxnrpQ0hn13fIaQPSVodaVAIjBW4vpFyuKFqs2LBKg6iolwZ21s8rEI0KR2gXl+8ugj0/UZ6YADiVM5w==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1512,7 +1512,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.6"
+        "@angular/core": "17.3.7"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -1521,9 +1521,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.3.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.6.tgz",
-      "integrity": "sha512-LaoUkY6uzcNocIEHJBvexvuU0a333IRQaG3Sj5IXhM1t864wTsfycn6yWJcQ7PhklB8BtNqiMbUQuEFtkxT8pg==",
+      "version": "17.3.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.7.tgz",
+      "integrity": "sha512-vSg5IQZ9jGmvYjpbfH8KbH4Sl1IVeE+Mr1ogcxkGEsURSRvKo7EWc0K7LSEI9+gg0VLamMiP9EyCJdPxiJeLJQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -1544,14 +1544,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.3.6",
+        "@angular/compiler": "17.3.7",
         "typescript": ">=5.2 <5.5"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.3.6",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.6.tgz",
-      "integrity": "sha512-8IoeZVNqyeHA+H2dR3VFfz76/TFN1BpXP0aABs2aIUNVQRYlKxALSm1UlavijX8IT0uvd/6GXwE3WgymTcg0wg==",
+      "version": "17.3.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.7.tgz",
+      "integrity": "sha512-HWcrbxqnvIMSxFuQdN0KPt08bc87hqr0LKm89yuRTUwx/2sNJlNQUobk6aJj4trswGBttcRDT+GOS4DQP2Nr4g==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1565,9 +1565,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.3.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.6.tgz",
-      "integrity": "sha512-UikrgvMwtZIXp2pCP5AtkM7ibz2B5wBiGpnhhkYsqHKy9ndKVDA+3B5Z+/j9xeYYdsJAAtHl45zqILewyg+4iw==",
+      "version": "17.3.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.7.tgz",
+      "integrity": "sha512-Nn8ZMaftAvO9dEwribWdNv+QBHhYIBrRkv85G6et80AXfXoYAr/xcfnQECRFtZgPmANqHC5auv/xrmExQG+Yeg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1576,9 +1576,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.3.6",
-        "@angular/common": "17.3.6",
-        "@angular/core": "17.3.6"
+        "@angular/animations": "17.3.7",
+        "@angular/common": "17.3.7",
+        "@angular/core": "17.3.7"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.3.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.6.tgz",
-      "integrity": "sha512-dI+mgEROmSll042+XqkSsvkMQe6Et6L9BBiYYe7VbIFaRR9Dz5Pw2SeBLb+Ou+gWaxXc2Wc+13n442WEYWZ7Ew==",
+      "version": "17.3.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.7.tgz",
+      "integrity": "sha512-9c2I4u0L1p2v1/lW8qy+WaNHisUWbyy6wqsv2v9FfCaSM49Lxymgo9LPFPC4qEG5ei5nE+eIQ2ocRiXXsf5QkQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1598,10 +1598,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.6",
-        "@angular/compiler": "17.3.6",
-        "@angular/core": "17.3.6",
-        "@angular/platform-browser": "17.3.6"
+        "@angular/common": "17.3.7",
+        "@angular/compiler": "17.3.7",
+        "@angular/core": "17.3.7",
+        "@angular/platform-browser": "17.3.7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.3.6"
+    "@angular/core": "^17.3.7"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.3.6",
@@ -37,11 +37,11 @@
     "@angular-eslint/schematics": "^17.3.0",
     "@angular-eslint/template-parser": "^17.3.0",
     "@angular/cli": "^17.3.6",
-    "@angular/common": "^17.3.6",
-    "@angular/compiler": "^17.3.6",
-    "@angular/compiler-cli": "^17.3.6",
-    "@angular/platform-browser": "^17.3.6",
-    "@angular/platform-browser-dynamic": "^17.3.6",
+    "@angular/common": "^17.3.7",
+    "@angular/compiler": "^17.3.7",
+    "@angular/compiler-cli": "^17.3.7",
+    "@angular/platform-browser": "^17.3.7",
+    "@angular/platform-browser-dynamic": "^17.3.7",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.12.4",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/core                           17.3.6 -> 17.3.7         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>