### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,17 @@
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^17.3.7",
-        "@angular-eslint/builder": "^17.4.0",
-        "@angular-eslint/eslint-plugin": "^17.4.0",
-        "@angular-eslint/eslint-plugin-template": "^17.4.0",
-        "@angular-eslint/schematics": "^17.4.0",
-        "@angular-eslint/template-parser": "^17.4.0",
+        "@angular-eslint/builder": "^17.4.1",
+        "@angular-eslint/eslint-plugin": "^17.4.1",
+        "@angular-eslint/eslint-plugin-template": "^17.4.1",
+        "@angular-eslint/schematics": "^17.4.1",
+        "@angular-eslint/template-parser": "^17.4.1",
         "@angular/cli": "^17.3.7",
-        "@angular/common": "^17.3.8",
-        "@angular/compiler": "^17.3.8",
-        "@angular/compiler-cli": "^17.3.8",
-        "@angular/platform-browser": "^17.3.8",
-        "@angular/platform-browser-dynamic": "^17.3.8",
+        "@angular/common": "^17.3.9",
+        "@angular/compiler": "^17.3.9",
+        "@angular/compiler-cli": "^17.3.9",
+        "@angular/platform-browser": "^17.3.9",
+        "@angular/platform-browser-dynamic": "^17.3.9",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.12.12",
@@ -48,7 +48,7 @@
         "zone.js": "^0.14.6"
       },
       "peerDependencies": {
-        "@angular/core": "^17.3.8"
+        "@angular/core": "^17.3.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -803,13 +803,13 @@
       "dev": true
     },
     "node_modules/@angular-eslint/builder": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-17.4.0.tgz",
-      "integrity": "sha512-+3ujbi+ar/iqAAwnJ2bTdWzQpHh9iVEPgjHUOeQhrEM8gcaOLnZXMlUyZL7D+NlXg7aDoEIxETb73dgbIBm55A==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-17.4.1.tgz",
+      "integrity": "sha512-UVnErsAGXTi8OChkoSxDVVGV2jkFpTaXQT+0fgapSwaOt3Ki7BVwJJoNaX0Zs01c64bjNPZ5ONb/i6nC8QiP9Q==",
       "dev": true,
       "dependencies": {
-        "@nx/devkit": "^17.2.8 || ^18.0.0",
-        "nx": "^17.2.8 || ^18.0.0"
+        "@nx/devkit": "^17.2.8 || ^18.0.0 || ^19.0.0",
+        "nx": "^17.2.8 || ^18.0.0 || ^19.0.0"
       },
       "peerDependencies": {
         "eslint": "^7.20.0 || ^8.0.0",
@@ -817,19 +817,19 @@
       }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-17.4.0.tgz",
-      "integrity": "sha512-cYEJs4PO+QLDt1wfgWh9q8OjOphnoe1OTTFtMqm9lHl0AkBynPnFA6ghiiG5NaT03l7HXi2TQ23rLFlXl3JOBg==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-17.4.1.tgz",
+      "integrity": "sha512-QKQGspxsyMHRwvzqo+Fj42TS/vmnwOHuWC6EN+5KBx3cuImahqFHQW842zVy9f65jfH2xDnNWJ+NW+Tzcgg+pQ==",
       "dev": true
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-17.4.0.tgz",
-      "integrity": "sha512-E+/O83PXttQUACurGEskLDU+wboBqMMVqvo4T8C/iMcpLx+01M5UBzqpCmfz6ri609G96Au7uDbUEedU1hwqmQ==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-17.4.1.tgz",
+      "integrity": "sha512-05bN1UB4H2CuX7Sw6fz+rMobsa+Bl3g15IYldH08hbJSnVemO8mf86bIjRN2Th79sO9WOiXXimnfIt7KRf8l0Q==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "17.4.0",
-        "@angular-eslint/utils": "17.4.0",
+        "@angular-eslint/bundled-angular-compiler": "17.4.1",
+        "@angular-eslint/utils": "17.4.1",
         "@typescript-eslint/utils": "7.8.0"
       },
       "peerDependencies": {
@@ -838,13 +838,13 @@
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-17.4.0.tgz",
-      "integrity": "sha512-o1Vb7rt3TpPChVzaxswOKBDWRboMcpC4qUUyoHfeSYa7sDuQHMeIQlCS5QXuykR/RYnIQJSKd89FOd28nGmmRw==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-17.4.1.tgz",
+      "integrity": "sha512-oYP7yzOpn63g1Mpwc8F8ERiywaGRhAs27ttI9t+5NXaLrwHSfc/AJleC7jjkB5xu1p88JY1mb4oIYOjeZAhHIg==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "17.4.0",
-        "@angular-eslint/utils": "17.4.0",
+        "@angular-eslint/bundled-angular-compiler": "17.4.1",
+        "@angular-eslint/utils": "17.4.1",
         "@typescript-eslint/type-utils": "7.8.0",
         "@typescript-eslint/utils": "7.8.0",
         "aria-query": "5.3.0",
@@ -1186,16 +1186,16 @@
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-17.4.0.tgz",
-      "integrity": "sha512-3WQQbwwBD1N3dZbbx1a1KY/jRujUQgz5778Ac21LU+AdCtvbjnmSpxRfsE3HH8MAreqr8Lv1kjLyiRzPTS5GQQ==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-17.4.1.tgz",
+      "integrity": "sha512-CYpsGc0B/ZGO/RKYlyfeAi1pOvFmVs4pvoHU13uOdhdFJ6nAUTujHiBaULloIrUmuIhGW9S0g6w4ecD6ZP680w==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/eslint-plugin": "17.4.0",
-        "@angular-eslint/eslint-plugin-template": "17.4.0",
-        "@nx/devkit": "^17.2.8 || ^18.0.0",
+        "@angular-eslint/eslint-plugin": "17.4.1",
+        "@angular-eslint/eslint-plugin-template": "17.4.1",
+        "@nx/devkit": "^17.2.8 || ^18.0.0 || ^19.0.0",
         "ignore": "5.3.1",
-        "nx": "^17.2.8 || ^18.0.0",
+        "nx": "^17.2.8 || ^18.0.0 || ^19.0.0",
         "strip-json-comments": "3.1.1",
         "tmp": "0.2.3"
       },
@@ -1204,12 +1204,12 @@
       }
     },
     "node_modules/@angular-eslint/template-parser": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-17.4.0.tgz",
-      "integrity": "sha512-vT/Tg8dl6Uy++MS9lPS0l37SynH3EaMcggDiTJqn15pIb4ePO65fafOIIKKYG+BN6R6iFe/g9mH/9nb8ohlzdQ==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-17.4.1.tgz",
+      "integrity": "sha512-fJQpwQXexgs7Z3yYpQAfuAkFB2Y5H8SSlo+eAPPafOOPpPSIm/yP4dQ2e06tE8zWB5yjYnVBMJnUKSmG5GJSDw==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "17.4.0",
+        "@angular-eslint/bundled-angular-compiler": "17.4.1",
         "eslint-scope": "^8.0.0"
       },
       "peerDependencies": {
@@ -1243,12 +1243,12 @@
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-17.4.0.tgz",
-      "integrity": "sha512-lHgRXyT878fauDITygraICDM6RHLb51QAJ3gWNZLr7SXcywsZg5d3rxRPCjrCnjgdxNPU0fJ+VJZ5AMt5Ibn7w==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-17.4.1.tgz",
+      "integrity": "sha512-ptpWSrN7hfLtbStOB5vlwjh088WRu+sT1XIXCROrX5uXR5sQMu5ZitnoObSe+Of+1lugguPvMvFm/pzTMp3LIg==",
       "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "17.4.0",
+        "@angular-eslint/bundled-angular-compiler": "17.4.1",
         "@typescript-eslint/utils": "7.8.0"
       },
       "peerDependencies": {
@@ -1477,9 +1477,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.8.tgz",
-      "integrity": "sha512-HEhTibrsWmoKilyhvAFmqg4SH1hWBP3eV9Y689lmsxBQCTRAmRI2pMAoRKQ+dBcoYLE/FZhcmdHJUSl5jR7Isg==",
+      "version": "17.3.9",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.9.tgz",
+      "integrity": "sha512-tH1VfbAvNVaz6ZYa+q0DiKtbmUql1jK/3q/af74B8nVjKLHcXVWwxvBayqvrmlUt7FGANGkETIcCWrB44k47Ug==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1488,14 +1488,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.8",
+        "@angular/core": "17.3.9",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.8.tgz",
-      "integrity": "sha512-7vZSh2Oa95lZdRR4MhE0icvZ7JUuYY+NSo3eTSOMZSlH5I9rtwQoSFqfoGW+35rXCzGFLOhQmZBbXkxDPDs97Q==",
+      "version": "17.3.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.9.tgz",
+      "integrity": "sha512-2d4bPbNm7O2GanqCj5GFgPDnmjbAcsQM502Jnvcv7Aje82yecT69JoqAVRqGOfbbxwlJiPhi31D8DPdLaOz47Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1504,7 +1504,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.8"
+        "@angular/core": "17.3.9"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -1513,9 +1513,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.8.tgz",
-      "integrity": "sha512-/TsbCmk7QJUEEZnRdNzi6znsPfoDJuy6vHDqcwWVEcw7y6W7DjirSFmtT9u1QwrV67KM6kOh22+RvPdGM8sPmg==",
+      "version": "17.3.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.9.tgz",
+      "integrity": "sha512-J6aqoz5wqPWaurbZFUZ7iMUlzAJYXzntziJJbalm6ceXfUWEe2Vm67nGUROWCIFvO3kWXvkgYX4ubnqtod2AxA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -1536,14 +1536,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.3.8",
+        "@angular/compiler": "17.3.9",
         "typescript": ">=5.2 <5.5"
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.8.tgz",
-      "integrity": "sha512-+tUQ+B1yVvNbczzaWBCgJWWIgZ2z+GVJWu+UNOHHWzdqD8qpXjuIkDfnhyLNeGvvXgsqey4u6ApFf2SoFYLjuA==",
+      "version": "17.3.9",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.9.tgz",
+      "integrity": "sha512-x+h5BQ6islvYWGVLTz1CEgNq1/5IYngQ+Inq/tWayM6jN7RPOCydCCbCw+uOZS7MgFebkP0gYTVm14y1MRFKSQ==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1557,9 +1557,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.8.tgz",
-      "integrity": "sha512-UMGSV3TdJqMtf2xvhbW6fx8TKJLOoHQgFxohhy3y8GvxHBu+PUyrwhovb7r03bs+muY6u4ygGCMm7Mt1TFVwfQ==",
+      "version": "17.3.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.9.tgz",
+      "integrity": "sha512-vMwHO76rnkz7aV3KHKy23KUFAo/+b0+yHPa6AND5Lee8z5C1J/tA2PdetFAsghlQQsX61JeK4MFJV/f3dFm2dw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1568,9 +1568,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.3.8",
-        "@angular/common": "17.3.8",
-        "@angular/core": "17.3.8"
+        "@angular/animations": "17.3.9",
+        "@angular/common": "17.3.9",
+        "@angular/core": "17.3.9"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1579,9 +1579,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.8.tgz",
-      "integrity": "sha512-uL6FPh+Pr9xzIjyiv3p66jteq/CytHP1+m5jOsIKa1LUwTXx0a2pmOYcZxXpNkQGR9Ir/dlbrYmKlSP3QZf7uw==",
+      "version": "17.3.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.9.tgz",
+      "integrity": "sha512-Jmth4hFC4dZsWQRkxB++42sR1pfJUoQbErANrKQMgEPb8H4cLRdB1mAQ6f+OASPBM+FsxDxjXq2kepyLGtF2Vg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1590,10 +1590,10 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.8",
-        "@angular/compiler": "17.3.8",
-        "@angular/core": "17.3.8",
-        "@angular/platform-browser": "17.3.8"
+        "@angular/common": "17.3.9",
+        "@angular/compiler": "17.3.9",
+        "@angular/core": "17.3.9",
+        "@angular/platform-browser": "17.3.9"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^17.3.8"
+    "@angular/core": "^17.3.9"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.3.7",
-    "@angular-eslint/builder": "^17.4.0",
-    "@angular-eslint/eslint-plugin": "^17.4.0",
-    "@angular-eslint/eslint-plugin-template": "^17.4.0",
-    "@angular-eslint/schematics": "^17.4.0",
-    "@angular-eslint/template-parser": "^17.4.0",
+    "@angular-eslint/builder": "^17.4.1",
+    "@angular-eslint/eslint-plugin": "^17.4.1",
+    "@angular-eslint/eslint-plugin-template": "^17.4.1",
+    "@angular-eslint/schematics": "^17.4.1",
+    "@angular-eslint/template-parser": "^17.4.1",
     "@angular/cli": "^17.3.7",
-    "@angular/common": "^17.3.8",
-    "@angular/compiler": "^17.3.8",
-    "@angular/compiler-cli": "^17.3.8",
-    "@angular/platform-browser": "^17.3.8",
-    "@angular/platform-browser-dynamic": "^17.3.8",
+    "@angular/common": "^17.3.9",
+    "@angular/compiler": "^17.3.9",
+    "@angular/compiler-cli": "^17.3.9",
+    "@angular/platform-browser": "^17.3.9",
+    "@angular/platform-browser-dynamic": "^17.3.9",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.12.12",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 38 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular-eslint/schematics              17.4.0 -> 17.4.1         ng update @angular-eslint/schematics
      @angular/core                           17.3.8 -> 17.3.9         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>