### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^18.2.6",
+        "@angular-devkit/build-angular": "^18.2.7",
         "@angular-eslint/builder": "^18.3.1",
         "@angular-eslint/eslint-plugin": "^18.3.1",
         "@angular-eslint/eslint-plugin-template": "^18.3.1",
         "@angular-eslint/schematics": "^18.3.1",
         "@angular-eslint/template-parser": "^18.3.1",
-        "@angular/cli": "^18.2.6",
-        "@angular/common": "^18.2.6",
-        "@angular/compiler": "^18.2.6",
-        "@angular/compiler-cli": "^18.2.6",
-        "@angular/platform-browser": "^18.2.6",
-        "@angular/platform-browser-dynamic": "^18.2.6",
+        "@angular/cli": "^18.2.7",
+        "@angular/common": "^18.2.7",
+        "@angular/compiler": "^18.2.7",
+        "@angular/compiler-cli": "^18.2.7",
+        "@angular/platform-browser": "^18.2.7",
+        "@angular/platform-browser-dynamic": "^18.2.7",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.7.2",
@@ -47,7 +47,7 @@
         "zone.js": "^0.14.10"
       },
       "peerDependencies": {
-        "@angular/core": "^18.2.6"
+        "@angular/core": "^18.2.7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -65,13 +65,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1802.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.6.tgz",
-      "integrity": "sha512-oF7cPFdTLxeuvXkK/opSdIxZ1E4LrBbmuytQ/nCoAGOaKBWdqvwagRZ6jVhaI0Gwu48rkcV7Zhesg/ESNnROdw==",
+      "version": "0.1802.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.7.tgz",
+      "integrity": "sha512-kpcgXnepEXcoxDTbqbGj7Hg1WJLWj1HLR3/FKmC5TbpBf1xiLxiqfkQNwz3BbE/W9JWMLdrXr3GI9O3O2gWPLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.6",
+        "@angular-devkit/core": "18.2.7",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -81,17 +81,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.6.tgz",
-      "integrity": "sha512-u12cJZttgs5j7gICHWSmcaTCu0EFXEzKqI8nkYCwq2MtuJlAXiMQSXYuEP9OU3Go4vMAPtQh2kShyOWCX5b4EQ==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.7.tgz",
+      "integrity": "sha512-u8PriYdgddK7k+OS/pOFPD1v4Iu5bztUJZXZVcGeXBZFFdnGFFzKmQw9mfcyGvTMJp2ABgBuuJT0YqYgNfAhzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.6",
-        "@angular-devkit/build-webpack": "0.1802.6",
-        "@angular-devkit/core": "18.2.6",
-        "@angular/build": "18.2.6",
+        "@angular-devkit/architect": "0.1802.7",
+        "@angular-devkit/build-webpack": "0.1802.7",
+        "@angular-devkit/core": "18.2.7",
+        "@angular/build": "18.2.7",
         "@babel/core": "7.25.2",
         "@babel/generator": "7.25.0",
         "@babel/helper-annotate-as-pure": "7.24.7",
@@ -102,7 +102,7 @@
         "@babel/preset-env": "7.25.3",
         "@babel/runtime": "7.25.0",
         "@discoveryjs/json-ext": "0.6.1",
-        "@ngtools/webpack": "18.2.6",
+        "@ngtools/webpack": "18.2.7",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -217,13 +217,13 @@
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1802.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.6.tgz",
-      "integrity": "sha512-JMLcXFaitJplwZMKkqhbYirINCRD6eOPZuIGaIOVynXYGWgvJkLT9t5C2wm9HqSLtp1K7NcYG2Y7PtTVR4krnQ==",
+      "version": "0.1802.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.7.tgz",
+      "integrity": "sha512-VrtbrhZ+dht3f0GjtfRLRGRN4XHN/W+/bA9DqckdxVS6SydsrCWNHonvEPmOs4jJmGIGXIu6tUBMcWleTao2sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.6",
+        "@angular-devkit/architect": "0.1802.7",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.6.tgz",
-      "integrity": "sha512-la4CFvs5PcRWSkQ/H7TB5cPZirFVA9GoWk5LzIk8si6VjWBJRm8b3keKJoC9LlNeABRUIR5z0ocYkyQQUhdMfg==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.7.tgz",
+      "integrity": "sha512-1ZTi4A6tEC2bkJ/puCIdIPYhesnlCVOMSDJL/lZAd0hC6X22T4pwu0AEvue7mcP5NbXpQDiBaXOZ3MmCA8PwOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -265,13 +265,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.6.tgz",
-      "integrity": "sha512-uIttrQ2cQ2PWAFFVPeCoNR8xvs7tPJ2i8gzqsIwYdge107xDC6u9CqfgmBqPDSFpWj+IiC2Jwcm8Z4HYKU4+7A==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.7.tgz",
+      "integrity": "sha512-j7198lpkOXMG+Gyfln/5aDgBZV7m4pWMzHFhkO3+w3cbCNUN1TVZW0SyJcF+CYaxANzTbuumfvpsYc/fTeAGLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.6",
+        "@angular-devkit/core": "18.2.7",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.11",
         "ora": "5.4.1",
@@ -384,14 +384,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.6.tgz",
-      "integrity": "sha512-TQzX6Mi7uXFvmz7+OVl4Za7WawYPcx+B5Ewm6IY/DdMyB9P/Z4tbKb1LO+ynWUXYwm7avXo6XQQ4m5ArDY5F/A==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.7.tgz",
+      "integrity": "sha512-oq6JsVxLP9/w9F2IjKroJwPB9CdlMblu2Xhfq/qQZRSUuM8Ppt1svr2FBTo1HrLIbosqukkVcSSdmKYDneo+cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.6",
+        "@angular-devkit/architect": "0.1802.7",
         "@babel/core": "7.25.2",
         "@babel/helper-annotate-as-pure": "7.24.7",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -453,18 +453,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.6.tgz",
-      "integrity": "sha512-tdXsnV/w+Rgu8q0zFsLU5L9ImTVqrTol1vppHaQkJ/vuoHy+s8ZEbBqhVrO/ffosNb2xseUybGYvqMS4zkNQjg==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.7.tgz",
+      "integrity": "sha512-KoWgSvhRsU05A2m6B7jw1kdpyoS+Ce5GGLW6xcnX7VF2AckW54vYd/8ZkgpzQrKfvIpVblYd4KJGizKoaLZ5jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.6",
-        "@angular-devkit/core": "18.2.6",
-        "@angular-devkit/schematics": "18.2.6",
+        "@angular-devkit/architect": "0.1802.7",
+        "@angular-devkit/core": "18.2.7",
+        "@angular-devkit/schematics": "18.2.7",
         "@inquirer/prompts": "5.3.8",
         "@listr2/prompt-adapter-inquirer": "2.0.15",
-        "@schematics/angular": "18.2.6",
+        "@schematics/angular": "18.2.7",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "4.1.3",
         "jsonc-parser": "3.3.1",
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.6.tgz",
-      "integrity": "sha512-89793ow+wrI1c7C6kyMbnweLNIZHzXthosxAEjipRZGBrqBYjvTtkE45Fl+5yBa3JO7bAhyGkUnEoyvWtZIAEA==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.7.tgz",
+      "integrity": "sha512-5vDBmBR2JcIxHVEDunKXNU+T+OvTGiHZTSo35GFOHJxKFgX5g6+0tJBZunK04oBZGbJQUmp3pg2kMvuKKjZnkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -499,14 +499,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.6",
+        "@angular/core": "18.2.7",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.6.tgz",
-      "integrity": "sha512-3tX2/Qw+bZ8XzKitviH8jzNGyY0uohhehhBB57OJOCc+yr4ojy/7SYFnun1lSsRnDztdCE461641X4iQLCQ94w==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.7.tgz",
+      "integrity": "sha512-XemlYyRGnu/HrICtXwTPmGtyOrI8BhbGg/HMiJ7sVx40AeEIX0uyDgnu9Gc5OjmtDqZZ8Qftg1sQAxaCVjLb1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -516,7 +516,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.6"
+        "@angular/core": "18.2.7"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.6.tgz",
-      "integrity": "sha512-b5x9STfjNiNM/S0D+CnqRP9UOxPtSz1+RlCH5WdOMiW/p8j5p6dBix8YYgTe6Wg3OD7eItD2pnFQKgF/dWiopA==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.7.tgz",
+      "integrity": "sha512-U7cveObj+rrXH5EC8egAhATCeAAcOceEQDTVIOWmBa0qMR4hOMjtI2XUS2QRuI1Q+fQZ2hVEOW95WVLvEMsANA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -549,14 +549,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "18.2.6",
+        "@angular/compiler": "18.2.7",
         "typescript": ">=5.4 <5.6"
       }
     },
     "node_modules/@angular/core": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.6.tgz",
-      "integrity": "sha512-PjFad2j4YBwLVTw+0Te8CJCa/tV0W8caTHG8aOjj3ObdL6ihGI+FKnwerLc9RVzDFd14BOO4C6/+LbOQAh3Ltw==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.7.tgz",
+      "integrity": "sha512-hLOxgxLiyWm9iVHBsUsJfx1hDsXWZnfJBlr+N7cev53f0CDoPfbshqq6KV+JFqXFDguzR9dKHm1ewT1jK3e6Tw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -571,9 +571,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.6.tgz",
-      "integrity": "sha512-RA8UMiYNLga+QMwpKcDw1357gYPfPyY/rmLeezMak//BbsENFYQOJ4Z6DBOBNiPlHxmBsUJMGaKdlpQhfCROyQ==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.7.tgz",
+      "integrity": "sha512-xgj2DH/isFrMZ73dJJm89NRnWBI3AHtugQrZbIapkKBdEt/C1o4SR2W2cV4mPb9o+ELnWurfrxFt9o/q2vnVLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -583,9 +583,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "18.2.6",
-        "@angular/common": "18.2.6",
-        "@angular/core": "18.2.6"
+        "@angular/animations": "18.2.7",
+        "@angular/common": "18.2.7",
+        "@angular/core": "18.2.7"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -594,9 +594,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.6.tgz",
-      "integrity": "sha512-kGBU3FNc+DF9r33hwHZqiWoZgQbCDdEIucU0NCLCIg0Hw6/Q9Hr2ndjxQI+WynCPg0JeBn34jpouvpeJer3YDQ==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.7.tgz",
+      "integrity": "sha512-BDldzUKjnUjo0NW5gHjBY6CeJP1bWVfF1h/T3idyYG+F4Lxlb3aykRgLWXg4srNLY1KqE7XOYUmgc5cV613bgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -606,10 +606,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "18.2.6",
-        "@angular/compiler": "18.2.6",
-        "@angular/core": "18.2.6",
-        "@angular/platform-browser": "18.2.6"
+        "@angular/common": "18.2.7",
+        "@angular/compiler": "18.2.7",
+        "@angular/core": "18.2.7",
+        "@angular/platform-browser": "18.2.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3603,9 +3603,9 @@
       }
     },
     "node_modules/@jsonjoy.com/util": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.3.0.tgz",
-      "integrity": "sha512-Cebt4Vk7k1xHy87kHY7KSPLT77A7Ev7IfOblyLZhtYEhrdQ6fX4EoLq3xOQ3O/DRMEh2ok5nyC180E+ABS8Wmw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.5.0.tgz",
+      "integrity": "sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3811,9 +3811,9 @@
       ]
     },
     "node_modules/@ngtools/webpack": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.6.tgz",
-      "integrity": "sha512-7HwOPE1EOgcHnpt4brSiT8G2CcXB50G0+CbCBaKGy4LYCG3Y3mrlzF5Fup9HvMJ6Tzqd62RqzpKKYBiGUT7hxg==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.7.tgz",
+      "integrity": "sha512-BmnFxss6zGobGyq9Mi7736golbK8RLgF+zYCQZ+4/OfMMA1jKVoELnyJqNyAx+DQn3m1qKVBjtGEL7pTNpPzOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4476,14 +4476,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.6.tgz",
-      "integrity": "sha512-Y988EoOEQDLEyHu3414T6AeVUyx21AexBHQNbUNQkK8cxlxyB6m1eH1cx6vFgLRFUTsLVv+C6Ln/ICNTfLcG4A==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.7.tgz",
+      "integrity": "sha512-WOBzO11qstznHbC9tZXQf6/8+PqmaRI6QYcdTspqXNh9q9nNglvi43Xn4tSIpEhW8aSHea9hgWZV8sG+i/4W9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.6",
-        "@angular-devkit/schematics": "18.2.6",
+        "@angular-devkit/core": "18.2.7",
+        "@angular-devkit/schematics": "18.2.7",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -17887,9 +17887,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^18.2.6"
+    "@angular/core": "^18.2.7"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.2.6",
+    "@angular-devkit/build-angular": "^18.2.7",
     "@angular-eslint/builder": "^18.3.1",
     "@angular-eslint/eslint-plugin": "^18.3.1",
     "@angular-eslint/eslint-plugin-template": "^18.3.1",
     "@angular-eslint/schematics": "^18.3.1",
     "@angular-eslint/template-parser": "^18.3.1",
-    "@angular/cli": "^18.2.6",
-    "@angular/common": "^18.2.6",
-    "@angular/compiler": "^18.2.6",
-    "@angular/compiler-cli": "^18.2.6",
-    "@angular/platform-browser": "^18.2.6",
-    "@angular/platform-browser-dynamic": "^18.2.6",
+    "@angular/cli": "^18.2.7",
+    "@angular/common": "^18.2.7",
+    "@angular/compiler": "^18.2.7",
+    "@angular/compiler-cli": "^18.2.7",
+    "@angular/platform-browser": "^18.2.7",
+    "@angular/platform-browser-dynamic": "^18.2.7",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.7.2",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 37 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            18.2.6 -> 18.2.7         ng update @angular/cli
      @angular/core                           18.2.6 -> 18.2.7         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>