### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^18.2.7",
+        "@angular-devkit/build-angular": "^18.2.8",
         "@angular-eslint/builder": "^18.3.1",
         "@angular-eslint/eslint-plugin": "^18.3.1",
         "@angular-eslint/eslint-plugin-template": "^18.3.1",
         "@angular-eslint/schematics": "^18.3.1",
         "@angular-eslint/template-parser": "^18.3.1",
-        "@angular/cli": "^18.2.7",
-        "@angular/common": "^18.2.7",
-        "@angular/compiler": "^18.2.7",
-        "@angular/compiler-cli": "^18.2.7",
-        "@angular/platform-browser": "^18.2.7",
-        "@angular/platform-browser-dynamic": "^18.2.7",
+        "@angular/cli": "^18.2.8",
+        "@angular/common": "^18.2.8",
+        "@angular/compiler": "^18.2.8",
+        "@angular/compiler-cli": "^18.2.8",
+        "@angular/platform-browser": "^18.2.8",
+        "@angular/platform-browser-dynamic": "^18.2.8",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.7.5",
@@ -47,7 +47,7 @@
         "zone.js": "^0.14.10"
       },
       "peerDependencies": {
-        "@angular/core": "^18.2.7"
+        "@angular/core": "^18.2.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -65,13 +65,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1802.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.7.tgz",
-      "integrity": "sha512-kpcgXnepEXcoxDTbqbGj7Hg1WJLWj1HLR3/FKmC5TbpBf1xiLxiqfkQNwz3BbE/W9JWMLdrXr3GI9O3O2gWPLg==",
+      "version": "0.1802.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.8.tgz",
+      "integrity": "sha512-/rtFQEKgS7LlB9oHr4NCBSdKnvP5kr8L5Hbd3Vl8hZOYK9QWjxKPEXnryA2d5+PCE98bBzZswCNXqELZCPTgIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.7",
+        "@angular-devkit/core": "18.2.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -81,17 +81,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.7.tgz",
-      "integrity": "sha512-u8PriYdgddK7k+OS/pOFPD1v4Iu5bztUJZXZVcGeXBZFFdnGFFzKmQw9mfcyGvTMJp2ABgBuuJT0YqYgNfAhzw==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.8.tgz",
+      "integrity": "sha512-qK/iLk7A8vQp1CyiJV4DpwfLjPKoiOlTtFqoO5vD8Tyxmc+R06FQp6GJTsZ7JtrTLYSiH+QAWiY6NgF/Rj/hHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.7",
-        "@angular-devkit/build-webpack": "0.1802.7",
-        "@angular-devkit/core": "18.2.7",
-        "@angular/build": "18.2.7",
+        "@angular-devkit/architect": "0.1802.8",
+        "@angular-devkit/build-webpack": "0.1802.8",
+        "@angular-devkit/core": "18.2.8",
+        "@angular/build": "18.2.8",
         "@babel/core": "7.25.2",
         "@babel/generator": "7.25.0",
         "@babel/helper-annotate-as-pure": "7.24.7",
@@ -102,7 +102,7 @@
         "@babel/preset-env": "7.25.3",
         "@babel/runtime": "7.25.0",
         "@discoveryjs/json-ext": "0.6.1",
-        "@ngtools/webpack": "18.2.7",
+        "@ngtools/webpack": "18.2.8",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -217,13 +217,13 @@
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1802.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.7.tgz",
-      "integrity": "sha512-VrtbrhZ+dht3f0GjtfRLRGRN4XHN/W+/bA9DqckdxVS6SydsrCWNHonvEPmOs4jJmGIGXIu6tUBMcWleTao2sg==",
+      "version": "0.1802.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.8.tgz",
+      "integrity": "sha512-uPpopkXkO66SSdjtVr7xCyQCPs/x6KUC76xkDc4j0b8EEHifTbi/fNpbkcZ6wBmoAfjKLWXfKvtkh0TqKK5Hkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.7",
+        "@angular-devkit/architect": "0.1802.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.7.tgz",
-      "integrity": "sha512-1ZTi4A6tEC2bkJ/puCIdIPYhesnlCVOMSDJL/lZAd0hC6X22T4pwu0AEvue7mcP5NbXpQDiBaXOZ3MmCA8PwOA==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.8.tgz",
+      "integrity": "sha512-4o2T6wsmXGE/v53+F8L7kGoN2+qzt03C9rtjLVQpOljzpJVttQ8bhvfWxyYLWwcl04RWqRa+82fpIZtBkOlZJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -265,13 +265,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.7.tgz",
-      "integrity": "sha512-j7198lpkOXMG+Gyfln/5aDgBZV7m4pWMzHFhkO3+w3cbCNUN1TVZW0SyJcF+CYaxANzTbuumfvpsYc/fTeAGLw==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.8.tgz",
+      "integrity": "sha512-i/h2Oji5FhJMC7wDSnIl5XUe/qym+C1ZwScaATJwDyRLCUIynZkj5rLgdG/uK6l+H0PgvxigkF+akWpokkwW6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.7",
+        "@angular-devkit/core": "18.2.8",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.11",
         "ora": "5.4.1",
@@ -384,14 +384,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.7.tgz",
-      "integrity": "sha512-oq6JsVxLP9/w9F2IjKroJwPB9CdlMblu2Xhfq/qQZRSUuM8Ppt1svr2FBTo1HrLIbosqukkVcSSdmKYDneo+cg==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.8.tgz",
+      "integrity": "sha512-ufuA4vHJSrL9SQW7bKV61DOoN1mm0t0ILTHaxSoCG3YF70cZJOX7+HNp3cK2uoldRMwbTOKSvCWBw54KKDRd5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.7",
+        "@angular-devkit/architect": "0.1802.8",
         "@babel/core": "7.25.2",
         "@babel/helper-annotate-as-pure": "7.24.7",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -453,18 +453,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.7.tgz",
-      "integrity": "sha512-KoWgSvhRsU05A2m6B7jw1kdpyoS+Ce5GGLW6xcnX7VF2AckW54vYd/8ZkgpzQrKfvIpVblYd4KJGizKoaLZ5jA==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.8.tgz",
+      "integrity": "sha512-GKXG7F7z5rxwZ8/bnW/Bp8/zsfE/BpHmIP/icLfUIOwv2kaY5OD2tfQssWXPEuqZzYq2AYz+wjVSbWjxGoja8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.7",
-        "@angular-devkit/core": "18.2.7",
-        "@angular-devkit/schematics": "18.2.7",
+        "@angular-devkit/architect": "0.1802.8",
+        "@angular-devkit/core": "18.2.8",
+        "@angular-devkit/schematics": "18.2.8",
         "@inquirer/prompts": "5.3.8",
         "@listr2/prompt-adapter-inquirer": "2.0.15",
-        "@schematics/angular": "18.2.7",
+        "@schematics/angular": "18.2.8",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "4.1.3",
         "jsonc-parser": "3.3.1",
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.7.tgz",
-      "integrity": "sha512-5vDBmBR2JcIxHVEDunKXNU+T+OvTGiHZTSo35GFOHJxKFgX5g6+0tJBZunK04oBZGbJQUmp3pg2kMvuKKjZnkQ==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.8.tgz",
+      "integrity": "sha512-TYsKtE5nVaIScWSLGSO34Skc+s3hB/BujSddnfQHoNFvPT/WR0dfmdlpVCTeLj+f50htFoMhW11tW99PbK+whQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -499,14 +499,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.7",
+        "@angular/core": "18.2.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.7.tgz",
-      "integrity": "sha512-XemlYyRGnu/HrICtXwTPmGtyOrI8BhbGg/HMiJ7sVx40AeEIX0uyDgnu9Gc5OjmtDqZZ8Qftg1sQAxaCVjLb1w==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.8.tgz",
+      "integrity": "sha512-JRedHNfK1CCPVyeGQB5w3WBYqMA6X8Q240CkvjlGfn0pVXihf9DWk3nkSQJVgYxpvpHfxdgjaYZ5IpMzlkmkhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -516,7 +516,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.7"
+        "@angular/core": "18.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -525,15 +525,15 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.7.tgz",
-      "integrity": "sha512-U7cveObj+rrXH5EC8egAhATCeAAcOceEQDTVIOWmBa0qMR4hOMjtI2XUS2QRuI1Q+fQZ2hVEOW95WVLvEMsANA==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.8.tgz",
+      "integrity": "sha512-OksDE4LWQUCcIvMjtZF7eiDCdIMrcMMpC1+Q0PIYi7KmnqXFGs4/Y0NdJvtn/LrQznzz5WaKM3ZDVNZTRX4wmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.25.2",
         "@jridgewell/sourcemap-codec": "^1.4.14",
-        "chokidar": "^3.0.0",
+        "chokidar": "^4.0.0",
         "convert-source-map": "^1.5.1",
         "reflect-metadata": "^0.2.0",
         "semver": "^7.0.0",
@@ -549,14 +549,44 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "18.2.7",
+        "@angular/compiler": "18.2.8",
         "typescript": ">=5.4 <5.6"
       }
     },
+    "node_modules/@angular/compiler-cli/node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@angular/compiler-cli/node_modules/readdirp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular/core": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.7.tgz",
-      "integrity": "sha512-hLOxgxLiyWm9iVHBsUsJfx1hDsXWZnfJBlr+N7cev53f0CDoPfbshqq6KV+JFqXFDguzR9dKHm1ewT1jK3e6Tw==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.8.tgz",
+      "integrity": "sha512-NwIuX/Iby1jT6Iv1/s6S3wOFf8xfuQR3MPGvKhGgNtjXLbHG+TXceK9+QPZC0s9/Z8JR/hz+li34B79GrIKgUg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -571,9 +601,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.7.tgz",
-      "integrity": "sha512-xgj2DH/isFrMZ73dJJm89NRnWBI3AHtugQrZbIapkKBdEt/C1o4SR2W2cV4mPb9o+ELnWurfrxFt9o/q2vnVLw==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.8.tgz",
+      "integrity": "sha512-EPai4ZPqSq3ilLJUC85kPi9wo5j5suQovwtgRyjM/75D9Qy4TV19g8hkVM5Co/zrltO8a2G6vDscCNI5BeGw2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -583,9 +613,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "18.2.7",
-        "@angular/common": "18.2.7",
-        "@angular/core": "18.2.7"
+        "@angular/animations": "18.2.8",
+        "@angular/common": "18.2.8",
+        "@angular/core": "18.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -594,9 +624,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.7.tgz",
-      "integrity": "sha512-BDldzUKjnUjo0NW5gHjBY6CeJP1bWVfF1h/T3idyYG+F4Lxlb3aykRgLWXg4srNLY1KqE7XOYUmgc5cV613bgw==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.8.tgz",
+      "integrity": "sha512-poZoapDqyN/rxGKQ3C6esdPiPLMkSpP2v12hoEa12KHgfPk7T1e+a+NMyJjV8HeOY3WyvL7tGRhW0NPTajTkhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -606,10 +636,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "18.2.7",
-        "@angular/compiler": "18.2.7",
-        "@angular/core": "18.2.7",
-        "@angular/platform-browser": "18.2.7"
+        "@angular/common": "18.2.8",
+        "@angular/compiler": "18.2.8",
+        "@angular/core": "18.2.8",
+        "@angular/platform-browser": "18.2.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3831,9 +3861,9 @@
       ]
     },
     "node_modules/@ngtools/webpack": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.7.tgz",
-      "integrity": "sha512-BmnFxss6zGobGyq9Mi7736golbK8RLgF+zYCQZ+4/OfMMA1jKVoELnyJqNyAx+DQn3m1qKVBjtGEL7pTNpPzOw==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.8.tgz",
+      "integrity": "sha512-sq0kI8gEen4QlM6X8XqOYy7j4B8iLCYNo+iKxatV36ts4AXH0MuVkP56+oMaoH5oZNoSqd0RlfnotEHfvJAr8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4496,14 +4526,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.7.tgz",
-      "integrity": "sha512-WOBzO11qstznHbC9tZXQf6/8+PqmaRI6QYcdTspqXNh9q9nNglvi43Xn4tSIpEhW8aSHea9hgWZV8sG+i/4W9Q==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.8.tgz",
+      "integrity": "sha512-62Sr7/j/dlhZorxH4GzQgpJy0s162BVts0Q7knZuEacP4VL+IWOUE1NS9OFkh/cbomoyXBdoewkZ5Zd1dVX78w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.7",
-        "@angular-devkit/schematics": "18.2.7",
+        "@angular-devkit/core": "18.2.8",
+        "@angular-devkit/schematics": "18.2.8",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -8685,9 +8715,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8696,7 +8726,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -8728,9 +8758,9 @@
       }
     },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12084,9 +12114,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.12.0.tgz",
-      "integrity": "sha512-74wDsex5tQDSClVkeK1vtxqYCAgCoXxx+K4NSHzgU/muYVYByFqa+0RnrPO9NM6naWm1+G9JmZ0p6QHhXmeYfA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.14.0.tgz",
+      "integrity": "sha512-JUeY0F/fQZgIod31Ja1eJgiSxLn7BfQlCnqhwXFBzFHEw63OdLK7VJUJ7bnzNsWgCyoUP5tEp1VRY8rDaYzqOA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13901,13 +13931,13 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.0.tgz",
+      "integrity": "sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^18.2.7"
+    "@angular/core": "^18.2.8"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.2.7",
+    "@angular-devkit/build-angular": "^18.2.8",
     "@angular-eslint/builder": "^18.3.1",
     "@angular-eslint/eslint-plugin": "^18.3.1",
     "@angular-eslint/eslint-plugin-template": "^18.3.1",
     "@angular-eslint/schematics": "^18.3.1",
     "@angular-eslint/template-parser": "^18.3.1",
-    "@angular/cli": "^18.2.7",
-    "@angular/common": "^18.2.7",
-    "@angular/compiler": "^18.2.7",
-    "@angular/compiler-cli": "^18.2.7",
-    "@angular/platform-browser": "^18.2.7",
-    "@angular/platform-browser-dynamic": "^18.2.7",
+    "@angular/cli": "^18.2.8",
+    "@angular/common": "^18.2.8",
+    "@angular/compiler": "^18.2.8",
+    "@angular/compiler-cli": "^18.2.8",
+    "@angular/platform-browser": "^18.2.8",
+    "@angular/platform-browser-dynamic": "^18.2.8",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.7.5",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 37 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            18.2.7 -> 18.2.8         ng update @angular/cli
      @angular/core                           18.2.7 -> 18.2.8         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>