### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^18.2.8",
+        "@angular-devkit/build-angular": "^18.2.9",
         "@angular-eslint/builder": "^18.3.1",
         "@angular-eslint/eslint-plugin": "^18.3.1",
         "@angular-eslint/eslint-plugin-template": "^18.3.1",
         "@angular-eslint/schematics": "^18.3.1",
         "@angular-eslint/template-parser": "^18.3.1",
-        "@angular/cli": "^18.2.8",
+        "@angular/cli": "^18.2.9",
         "@angular/common": "^18.2.8",
         "@angular/compiler": "^18.2.8",
         "@angular/compiler-cli": "^18.2.8",
@@ -65,13 +65,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1802.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.8.tgz",
-      "integrity": "sha512-/rtFQEKgS7LlB9oHr4NCBSdKnvP5kr8L5Hbd3Vl8hZOYK9QWjxKPEXnryA2d5+PCE98bBzZswCNXqELZCPTgIQ==",
+      "version": "0.1802.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.9.tgz",
+      "integrity": "sha512-fubJf4WC/t3ITy+tyjI4/CKKwUP4XJTmV+Y0nyPcrkcthVyUcIpZB74NlUOvg6WECiPQuIc+CtoAaA9X5+RQ5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.8",
+        "@angular-devkit/core": "18.2.9",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -81,17 +81,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "18.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.8.tgz",
-      "integrity": "sha512-qK/iLk7A8vQp1CyiJV4DpwfLjPKoiOlTtFqoO5vD8Tyxmc+R06FQp6GJTsZ7JtrTLYSiH+QAWiY6NgF/Rj/hHg==",
+      "version": "18.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.9.tgz",
+      "integrity": "sha512-d4W6t9vBozFUmOP2VvihMcSg/zgr3AvJY6/b7OPuATlK+W3P6tmsqxGIQ6eKc1TxXeu3lWhi14mV2pPykfrwfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.8",
-        "@angular-devkit/build-webpack": "0.1802.8",
-        "@angular-devkit/core": "18.2.8",
-        "@angular/build": "18.2.8",
+        "@angular-devkit/architect": "0.1802.9",
+        "@angular-devkit/build-webpack": "0.1802.9",
+        "@angular-devkit/core": "18.2.9",
+        "@angular/build": "18.2.9",
         "@babel/core": "7.25.2",
         "@babel/generator": "7.25.0",
         "@babel/helper-annotate-as-pure": "7.24.7",
@@ -102,7 +102,7 @@
         "@babel/preset-env": "7.25.3",
         "@babel/runtime": "7.25.0",
         "@discoveryjs/json-ext": "0.6.1",
-        "@ngtools/webpack": "18.2.8",
+        "@ngtools/webpack": "18.2.9",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -217,13 +217,13 @@
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1802.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.8.tgz",
-      "integrity": "sha512-uPpopkXkO66SSdjtVr7xCyQCPs/x6KUC76xkDc4j0b8EEHifTbi/fNpbkcZ6wBmoAfjKLWXfKvtkh0TqKK5Hkw==",
+      "version": "0.1802.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.9.tgz",
+      "integrity": "sha512-p7xNGo5ZTV/Z0Rk+q2/E68QQLw9VT33kauDh6s010jIeBLrOwMo74JpzXMSFttQo5O4bLKP8IORzIM+0q7Uzjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.8",
+        "@angular-devkit/architect": "0.1802.9",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "18.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.8.tgz",
-      "integrity": "sha512-4o2T6wsmXGE/v53+F8L7kGoN2+qzt03C9rtjLVQpOljzpJVttQ8bhvfWxyYLWwcl04RWqRa+82fpIZtBkOlZJw==",
+      "version": "18.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.9.tgz",
+      "integrity": "sha512-bsVt//5E0ua7FZfO0dCF/qGGY6KQD34/bNGyRu5B6HedimpdU2/0PGDptksU5v3yKEc9gNw0xC6mT0UsY/R9pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -265,13 +265,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "18.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.8.tgz",
-      "integrity": "sha512-i/h2Oji5FhJMC7wDSnIl5XUe/qym+C1ZwScaATJwDyRLCUIynZkj5rLgdG/uK6l+H0PgvxigkF+akWpokkwW6w==",
+      "version": "18.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.9.tgz",
+      "integrity": "sha512-aIY5/IomDOINGCtFYi77uo0acDpdQNNCighfBBUGEBNMQ1eE3oGNGpLAH/qWeuxJndgmxrdKsvws9DdT46kLig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.8",
+        "@angular-devkit/core": "18.2.9",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.11",
         "ora": "5.4.1",
@@ -384,14 +384,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "18.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.8.tgz",
-      "integrity": "sha512-ufuA4vHJSrL9SQW7bKV61DOoN1mm0t0ILTHaxSoCG3YF70cZJOX7+HNp3cK2uoldRMwbTOKSvCWBw54KKDRd5Q==",
+      "version": "18.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.9.tgz",
+      "integrity": "sha512-o1hOEM2e6ARy+ck2Pohl0d/RFgbbXTw6/hTLAj3CBKjtqAGStRaVF2UlJjhi+xOxlfsOPuJJc9IpzLBteku+Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.8",
+        "@angular-devkit/architect": "0.1802.9",
         "@babel/core": "7.25.2",
         "@babel/helper-annotate-as-pure": "7.24.7",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -453,18 +453,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "18.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.8.tgz",
-      "integrity": "sha512-GKXG7F7z5rxwZ8/bnW/Bp8/zsfE/BpHmIP/icLfUIOwv2kaY5OD2tfQssWXPEuqZzYq2AYz+wjVSbWjxGoja8A==",
+      "version": "18.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.9.tgz",
+      "integrity": "sha512-ejTIqwvPABwK7MtVmI2qWbEaMhhbHNsq0NPzl1hwLtkrLbjdDrEVv0Wy+gN0xqrT9NyCPl4AmNLz/xuYTzgU5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.8",
-        "@angular-devkit/core": "18.2.8",
-        "@angular-devkit/schematics": "18.2.8",
+        "@angular-devkit/architect": "0.1802.9",
+        "@angular-devkit/core": "18.2.9",
+        "@angular-devkit/schematics": "18.2.9",
         "@inquirer/prompts": "5.3.8",
         "@listr2/prompt-adapter-inquirer": "2.0.15",
-        "@schematics/angular": "18.2.8",
+        "@schematics/angular": "18.2.9",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "4.1.3",
         "jsonc-parser": "3.3.1",
@@ -3861,9 +3861,9 @@
       ]
     },
     "node_modules/@ngtools/webpack": {
-      "version": "18.2.8",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.8.tgz",
-      "integrity": "sha512-sq0kI8gEen4QlM6X8XqOYy7j4B8iLCYNo+iKxatV36ts4AXH0MuVkP56+oMaoH5oZNoSqd0RlfnotEHfvJAr8A==",
+      "version": "18.2.9",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.9.tgz",
+      "integrity": "sha512-/apDvs4qevjSWoYw3h3/c/mILFrf2EgCJfBy9f3E7PEgi2tjifOIszBRrLQkVpeHAaFgEH8zKS2ol0hAmOl8sw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4526,14 +4526,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "18.2.8",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.8.tgz",
-      "integrity": "sha512-62Sr7/j/dlhZorxH4GzQgpJy0s162BVts0Q7knZuEacP4VL+IWOUE1NS9OFkh/cbomoyXBdoewkZ5Zd1dVX78w==",
+      "version": "18.2.9",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.9.tgz",
+      "integrity": "sha512-LlMHZQ6f8zrqSK24OBXi4u2MTNHNu9ZN6JXpbElq0bz/9QkUR2zy+Kk2wLpPxCwXYTZby7/xgHiTzXvG+zTdhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.8",
-        "@angular-devkit/schematics": "18.2.8",
+        "@angular-devkit/core": "18.2.9",
+        "@angular-devkit/schematics": "18.2.9",
         "jsonc-parser": "3.3.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "@angular/core": "^18.2.8"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.2.8",
+    "@angular-devkit/build-angular": "^18.2.9",
     "@angular-eslint/builder": "^18.3.1",
     "@angular-eslint/eslint-plugin": "^18.3.1",
     "@angular-eslint/eslint-plugin-template": "^18.3.1",
     "@angular-eslint/schematics": "^18.3.1",
     "@angular-eslint/template-parser": "^18.3.1",
-    "@angular/cli": "^18.2.8",
+    "@angular/cli": "^18.2.9",
     "@angular/common": "^18.2.8",
     "@angular/compiler": "^18.2.8",
     "@angular/compiler-cli": "^18.2.8",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 37 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            18.2.8 -> 18.2.9         ng update @angular/cli
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>