### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^18.2.10",
+        "@angular-devkit/build-angular": "^18.2.11",
         "@angular-eslint/builder": "^18.4.0",
         "@angular-eslint/eslint-plugin": "^18.4.0",
         "@angular-eslint/eslint-plugin-template": "^18.4.0",
         "@angular-eslint/schematics": "^18.4.0",
         "@angular-eslint/template-parser": "^18.4.0",
-        "@angular/cli": "^18.2.10",
-        "@angular/common": "^18.2.9",
-        "@angular/compiler": "^18.2.9",
-        "@angular/compiler-cli": "^18.2.9",
-        "@angular/platform-browser": "^18.2.9",
-        "@angular/platform-browser-dynamic": "^18.2.9",
+        "@angular/cli": "^18.2.11",
+        "@angular/common": "^18.2.10",
+        "@angular/compiler": "^18.2.10",
+        "@angular/compiler-cli": "^18.2.10",
+        "@angular/platform-browser": "^18.2.10",
+        "@angular/platform-browser-dynamic": "^18.2.10",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.8.6",
@@ -47,7 +47,7 @@
         "zone.js": "^0.14.10"
       },
       "peerDependencies": {
-        "@angular/core": "^18.2.9"
+        "@angular/core": "^18.2.10"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -65,13 +65,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1802.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.10.tgz",
-      "integrity": "sha512-/xudcHK2s4J/GcL6qyobmGaWMHQcYLSMqCaWMT+nK6I6tu9VEAj/p3R83Tzx8B/eKi31Pz499uHw9pmqdtbafg==",
+      "version": "0.1802.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.11.tgz",
+      "integrity": "sha512-p+XIc/j51aI83ExNdeZwvkm1F4wkuKMGUUoj0MVUUi5E6NoiMlXYm6uU8+HbRvPBzGy5+3KOiGp3Fks0UmDSAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.10",
+        "@angular-devkit/core": "18.2.11",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -81,17 +81,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.10.tgz",
-      "integrity": "sha512-47XgJ5fdIqlZUFWAo/XtNsh3y597DtLZWvfsnwShw6/TgyiV0rbL1Z24Rn2TCV1D/b3VhLutAIIZ/i5O5BirxQ==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.11.tgz",
+      "integrity": "sha512-09Ln3NAdlMw/wMLgnwYU5VgWV5TPBEHolZUIvE9D8b6SFWBCowk3B3RWeAMgg7Peuf9SKwqQHBz2b1C7RTP/8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.10",
-        "@angular-devkit/build-webpack": "0.1802.10",
-        "@angular-devkit/core": "18.2.10",
-        "@angular/build": "18.2.10",
+        "@angular-devkit/architect": "0.1802.11",
+        "@angular-devkit/build-webpack": "0.1802.11",
+        "@angular-devkit/core": "18.2.11",
+        "@angular/build": "18.2.11",
         "@babel/core": "7.25.2",
         "@babel/generator": "7.25.0",
         "@babel/helper-annotate-as-pure": "7.24.7",
@@ -102,7 +102,7 @@
         "@babel/preset-env": "7.25.3",
         "@babel/runtime": "7.25.0",
         "@discoveryjs/json-ext": "0.6.1",
-        "@ngtools/webpack": "18.2.10",
+        "@ngtools/webpack": "18.2.11",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -217,13 +217,13 @@
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1802.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.10.tgz",
-      "integrity": "sha512-WRftK/RJ9rBDDmkx5IAtIpyNo0DJiMfgGUTuZNpNUaJfSfGeaSZYgC7o1++axMchID8pncmI3Hr8L8gaP94WQg==",
+      "version": "0.1802.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.11.tgz",
+      "integrity": "sha512-G76rNsyn1iQk7qjyr+K4rnDzfalmEswmwXQorypSDGaHYzIDY1SZXMoP4225WMq5fJNBOJrk82FA0PSfnPE+zQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.10",
+        "@angular-devkit/architect": "0.1802.11",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.10.tgz",
-      "integrity": "sha512-LFqiNdraBujg8e1lhuB0bkFVAoIbVbeXXwfoeROKH60OPbP8tHdgV6sFTqU7UGBKA+b+bYye70KFTG2Ys8QzKQ==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.11.tgz",
+      "integrity": "sha512-H9P1shRGigORWJHUY2BRa2YurT+DVminrhuaYHsbhXBRsPmgB2Dx/30YLTnC1s5XmR9QIRUCsg/d3kyT1wd5Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -265,13 +265,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.10.tgz",
-      "integrity": "sha512-EIm/yCYg3ZYPsPYJxXRX5F6PofJCbNQ5rZEuQEY09vy+ZRTqGezH0qoUP5WxlYeJrjiRLYqADI9WtVNzDyaD4w==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.11.tgz",
+      "integrity": "sha512-efRK3FotTFp4KD5u42jWfXpHUALXB9kJNsWiB4wEImKFH6CN+vjBspJQuLqk2oeBFh/7D2qRMc5P+2tZHM5hdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.10",
+        "@angular-devkit/core": "18.2.11",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.11",
         "ora": "5.4.1",
@@ -385,14 +385,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.10.tgz",
-      "integrity": "sha512-YFBKvAyC5sH17yRYcx7VHCtJ4KUg7xCjCQ4Pe16kiTvW6vuYsgU6Btyti0Qgewd7XaWpTM8hk8N6hE4Z0hpflw==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.11.tgz",
+      "integrity": "sha512-AgirvSCmqUKiDE3C0rl3JA68OkOqQWDKUvjqRHXCkhxldLVOVoeIl87+jBYK/v9gcmk+K+ju+5wbGEfu1FjhiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.10",
+        "@angular-devkit/architect": "0.1802.11",
         "@babel/core": "7.25.2",
         "@babel/helper-annotate-as-pure": "7.24.7",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -454,18 +454,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.10.tgz",
-      "integrity": "sha512-qW/F3XVZMzzenFzbn+7FGpw8GOt9qW8UxBtYya7gUNdWlcsgGUk+ZaGC2OLbfI5gX6pchW4TOPMsDSMeaCEI2Q==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.11.tgz",
+      "integrity": "sha512-0JI1xjOLRemBPjdT/yVlabxc3Zkjqa/lhvVxxVC1XhKoW7yGxIGwNrQ4pka4CcQtCuktO6KPMmTGIu8YgC3cpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.10",
-        "@angular-devkit/core": "18.2.10",
-        "@angular-devkit/schematics": "18.2.10",
+        "@angular-devkit/architect": "0.1802.11",
+        "@angular-devkit/core": "18.2.11",
+        "@angular-devkit/schematics": "18.2.11",
         "@inquirer/prompts": "5.3.8",
         "@listr2/prompt-adapter-inquirer": "2.0.15",
-        "@schematics/angular": "18.2.10",
+        "@schematics/angular": "18.2.11",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "4.1.3",
         "jsonc-parser": "3.3.1",
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "18.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.9.tgz",
-      "integrity": "sha512-Opi6DVaU0aGyJqLk5jPmeYx559fp3afj4wuxM5aDzV4KEVGDVbNCpO0hMuwHZ6rtCjHhv1fQthgS48qoiQ6LKw==",
+      "version": "18.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.10.tgz",
+      "integrity": "sha512-YzTCmuqLiOuT+Yv07vuKymDWiebOVZ8BuXakJiz4EM7FMoOw5gICHJ04jepZSjDNWpA16e7kJSdt5ucnmvCFDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -500,14 +500,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.9",
+        "@angular/core": "18.2.10",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "18.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.9.tgz",
-      "integrity": "sha512-fchbcbsyTOd/qHGy+yPEmE1p10OTNEjGrWHQzUbf3xdlm23EvxHTitHh8i6EBdwYnM5zz0IIBhltP8tt89oeYw==",
+      "version": "18.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.10.tgz",
+      "integrity": "sha512-cu+Uq1nnyl00Glg0+2uvm+Xpaq5b4YvWpaLGGtit7uGETAJ4L/frlBVeaTRhEoaIAGBI+RRlyuFLae+etQDA0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -517,7 +517,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.9"
+        "@angular/core": "18.2.10"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -526,9 +526,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "18.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.9.tgz",
-      "integrity": "sha512-4iMoRvyMmq/fdI/4Gob9HKjL/jvTlCjbS4kouAYHuGO9w9dmUhi1pY1z+mALtCEl9/Q8CzU2W8e5cU2xtV4nVg==",
+      "version": "18.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.10.tgz",
+      "integrity": "sha512-CNFStKWMB89MFKAZZFUOhoQi+fHqRLgNOOrI73LjizXixvngEh3BDZJRtK9hbSGG+giujBrummEA60CWAw69MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -550,7 +550,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "18.2.9",
+        "@angular/compiler": "18.2.10",
         "typescript": ">=5.4 <5.6"
       }
     },
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "18.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.9.tgz",
-      "integrity": "sha512-h9/Bzo/7LTPzzh9I/1Gk8TWOXPGeHt3jLlnYrCh2KbrWbTErNtW0V3ad5I3Zv+K2Z7RSl9Z3D3Y6ILH796N4ZA==",
+      "version": "18.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.10.tgz",
+      "integrity": "sha512-EfxVz0pLaxnOppOYkdhnaUkk8HZT+uxaAGpJD3ppAa7YAWTE9xIGoNJmtS33cZNNOnvriMkdv7yn6pDtV4ct+Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "18.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.9.tgz",
-      "integrity": "sha512-UNu6XjK0SV35FFe55yd1yefZI8tzflVKzev/RzC31XngrczhlH0+WCbae4rG1XJULzJwJ1R1p7gqq4+ktEczRQ==",
+      "version": "18.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.10.tgz",
+      "integrity": "sha512-zKyRKFr3AaEA4SE/DEeb5FWHJutT26avHZog6ZGDkMeMN12zMtSqjPuTSgmDXCWleoOkzbb+nhAQ+fK/EyGyPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -614,9 +614,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "18.2.9",
-        "@angular/common": "18.2.9",
-        "@angular/core": "18.2.9"
+        "@angular/animations": "18.2.10",
+        "@angular/common": "18.2.10",
+        "@angular/core": "18.2.10"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "18.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.9.tgz",
-      "integrity": "sha512-cUTB8Jc3I/fu2UKv/PJmNGQGvKyyTo8ln4GUX3EJ4wUHzgkrU0s4x7DNok0Ql8FZKs5dLR8C0xVbG7Dv/ViPdw==",
+      "version": "18.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.10.tgz",
+      "integrity": "sha512-syKyOTgfQnMxfpDRP1khTSPZ5dsMgA8YQwNF6KsB3eZQl15CKSka7bzjMOUWeZ8M3WShOp1AzTf0MfwNeh0UBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -637,10 +637,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "18.2.9",
-        "@angular/compiler": "18.2.9",
-        "@angular/core": "18.2.9",
-        "@angular/platform-browser": "18.2.9"
+        "@angular/common": "18.2.10",
+        "@angular/compiler": "18.2.10",
+        "@angular/core": "18.2.10",
+        "@angular/platform-browser": "18.2.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3861,9 +3861,9 @@
       ]
     },
     "node_modules/@ngtools/webpack": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.10.tgz",
-      "integrity": "sha512-CGYr8rdM5ntdb4kLUAhrLBPrhJQ4KBPo3KMT6qJE/S+jJJn5zHzedpuGFOCVhC1Siw+n1pOBSI8leTRJIW/eCQ==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.11.tgz",
+      "integrity": "sha512-iTdUGJ5O7yMm1DyCzyoMDMxBJ68emUSSXPWbQzEEdcqmtifRebn+VAq4vHN8OmtGM1mtuKeLEsbiZP8ywrw7Ug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4526,14 +4526,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.10.tgz",
-      "integrity": "sha512-2pDHT4aSzfs8Up4RQmHHuFd5FeuUebS1ZJwyt46MfXzRMFtzUZV/JKsIvDqyMwnkvFfLvgJyTCkl8JGw5jQObg==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.11.tgz",
+      "integrity": "sha512-jT54mc9+hPOwie9bji/g2krVuK1kkNh2PNFGwfgCg3Ofmt3hcyOBai1DKuot5uLTX4VCCbvfwiVR/hJniQl2SA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.10",
-        "@angular-devkit/schematics": "18.2.10",
+        "@angular-devkit/core": "18.2.11",
+        "@angular-devkit/schematics": "18.2.11",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -4947,9 +4947,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6582,32 +6582,22 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.5.tgz",
+      "integrity": "sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.5",
-        "bytes": "3.0.0",
-        "compressible": "~2.0.16",
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
         "debug": "2.6.9",
+        "negotiator": "~0.6.4",
         "on-headers": "~1.0.2",
-        "safe-buffer": "5.1.2",
+        "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/compression/node_modules/bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/compression/node_modules/debug": {
@@ -6627,12 +6617,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/compression/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7203,6 +7196,7 @@
       "version": "0.0.24",
       "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.24.tgz",
       "integrity": "sha512-Oyqew0FGM0wYUSNqR0L6AteO5MpMoUU0rhKRieXeiKs+PmRTxiJMyaunYB2KF6fQ3dzChXKCpbFOEJx3OQ1v/Q==",
+      "deprecated": "Ownership of Critters has moved to the Nuxt team, who will be maintaining the project going forward. If you'd like to keep using Critters, please switch to the actively-maintained fork at https://github.com/danielroe/beasties",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12801,9 +12795,9 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.0.tgz",
-      "integrity": "sha512-I8qXuuALqJe5laEBYoFykChhSXLikZmUhccjGsPuSJ/7uPip2TJ7lwdIQwWSAi0jGZDXv4WOP8Qg65QZRuXxXw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.2.tgz",
+      "integrity": "sha512-F9UngXRlPyWCDEASDpTf6c9uNhGPTqnTeLVt7bN+bU1eajoR/8V9ys2BRaV5C/e5ihE6sJ9uPIKaYt6bFuO32g==",
       "dev": true,
       "license": "MIT",
       "optionalDependencies": {
@@ -13705,9 +13699,9 @@
       }
     },
     "node_modules/ordered-binary": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.2.tgz",
-      "integrity": "sha512-JTo+4+4Fw7FreyAvlSLjb1BBVaxEQAacmjD3jjuyPZclpbEghTvQZbXBb2qPd2LeIMxiHwXBZUcpmG2Gl/mDEA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.3.tgz",
+      "integrity": "sha512-oGFr3T+pYdTGJ+YFEILMpS3es+GiIbs9h/XQrclBXUtd44ey7XwfsMzM31f64I1SQOawDoDr/D823kNCADI8TA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13928,9 +13922,9 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.0.tgz",
-      "integrity": "sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^18.2.9"
+    "@angular/core": "^18.2.10"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.2.10",
+    "@angular-devkit/build-angular": "^18.2.11",
     "@angular-eslint/builder": "^18.4.0",
     "@angular-eslint/eslint-plugin": "^18.4.0",
     "@angular-eslint/eslint-plugin-template": "^18.4.0",
     "@angular-eslint/schematics": "^18.4.0",
     "@angular-eslint/template-parser": "^18.4.0",
-    "@angular/cli": "^18.2.10",
-    "@angular/common": "^18.2.9",
-    "@angular/compiler": "^18.2.9",
-    "@angular/compiler-cli": "^18.2.9",
-    "@angular/platform-browser": "^18.2.9",
-    "@angular/platform-browser-dynamic": "^18.2.9",
+    "@angular/cli": "^18.2.11",
+    "@angular/common": "^18.2.10",
+    "@angular/compiler": "^18.2.10",
+    "@angular/compiler-cli": "^18.2.10",
+    "@angular/platform-browser": "^18.2.10",
+    "@angular/platform-browser-dynamic": "^18.2.10",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.8.6",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 37 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            18.2.10 -> 18.2.11       ng update @angular/cli
      @angular/core                           18.2.9 -> 18.2.10        ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>