### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "@angular-eslint/schematics": "^18.4.0",
         "@angular-eslint/template-parser": "^18.4.0",
         "@angular/cli": "^18.2.11",
-        "@angular/common": "^18.2.10",
-        "@angular/compiler": "^18.2.10",
-        "@angular/compiler-cli": "^18.2.10",
-        "@angular/platform-browser": "^18.2.10",
-        "@angular/platform-browser-dynamic": "^18.2.10",
+        "@angular/common": "^18.2.11",
+        "@angular/compiler": "^18.2.11",
+        "@angular/compiler-cli": "^18.2.11",
+        "@angular/platform-browser": "^18.2.11",
+        "@angular/platform-browser-dynamic": "^18.2.11",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.9.0",
@@ -47,7 +47,7 @@
         "zone.js": "^0.14.10"
       },
       "peerDependencies": {
-        "@angular/core": "^18.2.10"
+        "@angular/core": "^18.2.11"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.10.tgz",
-      "integrity": "sha512-YzTCmuqLiOuT+Yv07vuKymDWiebOVZ8BuXakJiz4EM7FMoOw5gICHJ04jepZSjDNWpA16e7kJSdt5ucnmvCFDQ==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.11.tgz",
+      "integrity": "sha512-bamJeISl2zUlvjPYebQWazUjhjXU9nrot42cQJng94SkvNENT9LTWfPYgc+Bd972Kg+31jG4H41rgFNs7zySmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -500,14 +500,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.10",
+        "@angular/core": "18.2.11",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.10.tgz",
-      "integrity": "sha512-cu+Uq1nnyl00Glg0+2uvm+Xpaq5b4YvWpaLGGtit7uGETAJ4L/frlBVeaTRhEoaIAGBI+RRlyuFLae+etQDA0w==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.11.tgz",
+      "integrity": "sha512-PSVL1YXUhTzkgJNYXiWk9eAZxNV6laQJRGdj9++C1q9m2S9/GlehZGzkt5GtC5rlUweJucCNvBC1+2D5FAt9vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -517,7 +517,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.10"
+        "@angular/core": "18.2.11"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -526,9 +526,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.10.tgz",
-      "integrity": "sha512-CNFStKWMB89MFKAZZFUOhoQi+fHqRLgNOOrI73LjizXixvngEh3BDZJRtK9hbSGG+giujBrummEA60CWAw69MA==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.11.tgz",
+      "integrity": "sha512-YJlAOiXZUYP6/RK9isu5AOucmNZhFB9lpY/beMzkkWgDku+va8szm4BZbLJFz176IUteyLWF3IP4aE7P9OBlXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -550,7 +550,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "18.2.10",
+        "@angular/compiler": "18.2.11",
         "typescript": ">=5.4 <5.6"
       }
     },
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.10.tgz",
-      "integrity": "sha512-EfxVz0pLaxnOppOYkdhnaUkk8HZT+uxaAGpJD3ppAa7YAWTE9xIGoNJmtS33cZNNOnvriMkdv7yn6pDtV4ct+Q==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.11.tgz",
+      "integrity": "sha512-/AGAFyZN8KR+kW5FUFCCBCj3qHyDDum7G0lJe5otrT9AqF6+g7PjF8yLha/6wPkJG7ri5xGLhini1sEivVeq/g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.10.tgz",
-      "integrity": "sha512-zKyRKFr3AaEA4SE/DEeb5FWHJutT26avHZog6ZGDkMeMN12zMtSqjPuTSgmDXCWleoOkzbb+nhAQ+fK/EyGyPA==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.11.tgz",
+      "integrity": "sha512-bzcP0QdPT/ncTxOx0t7901z5m0wDmkraTo/es4g8reV6VK9Ptv0QDuD8aDvrHh7sLCX5VgwDF9ohc6S2TpYUCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -614,9 +614,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "18.2.10",
-        "@angular/common": "18.2.10",
-        "@angular/core": "18.2.10"
+        "@angular/animations": "18.2.11",
+        "@angular/common": "18.2.11",
+        "@angular/core": "18.2.11"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "18.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.10.tgz",
-      "integrity": "sha512-syKyOTgfQnMxfpDRP1khTSPZ5dsMgA8YQwNF6KsB3eZQl15CKSka7bzjMOUWeZ8M3WShOp1AzTf0MfwNeh0UBA==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.11.tgz",
+      "integrity": "sha512-a30U4ZdTZSvL17xWwOq6xh9ToCDP2K7/j1HTJFREObbuAtZTa/6IVgBUM6oOMNQ43kHkT6Mr9Emkgf9iGtWwfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -637,10 +637,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "18.2.10",
-        "@angular/compiler": "18.2.10",
-        "@angular/core": "18.2.10",
-        "@angular/platform-browser": "18.2.10"
+        "@angular/common": "18.2.11",
+        "@angular/compiler": "18.2.11",
+        "@angular/core": "18.2.11",
+        "@angular/platform-browser": "18.2.11"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^18.2.10"
+    "@angular/core": "^18.2.11"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^18.2.11",
@@ -37,11 +37,11 @@
     "@angular-eslint/schematics": "^18.4.0",
     "@angular-eslint/template-parser": "^18.4.0",
     "@angular/cli": "^18.2.11",
-    "@angular/common": "^18.2.10",
-    "@angular/compiler": "^18.2.10",
-    "@angular/compiler-cli": "^18.2.10",
-    "@angular/platform-browser": "^18.2.10",
-    "@angular/platform-browser-dynamic": "^18.2.10",
+    "@angular/common": "^18.2.11",
+    "@angular/compiler": "^18.2.11",
+    "@angular/compiler-cli": "^18.2.11",
+    "@angular/platform-browser": "^18.2.11",
+    "@angular/platform-browser-dynamic": "^18.2.11",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.9.0",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 37 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/core                           18.2.10 -> 18.2.11       ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>