### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^18.2.11",
+        "@angular-devkit/build-angular": "^18.2.12",
         "@angular-eslint/builder": "^18.4.0",
         "@angular-eslint/eslint-plugin": "^18.4.0",
         "@angular-eslint/eslint-plugin-template": "^18.4.0",
         "@angular-eslint/schematics": "^18.4.0",
         "@angular-eslint/template-parser": "^18.4.0",
-        "@angular/cli": "^18.2.11",
-        "@angular/common": "^18.2.11",
-        "@angular/compiler": "^18.2.11",
-        "@angular/compiler-cli": "^18.2.11",
-        "@angular/platform-browser": "^18.2.11",
-        "@angular/platform-browser-dynamic": "^18.2.11",
+        "@angular/cli": "^18.2.12",
+        "@angular/common": "^18.2.12",
+        "@angular/compiler": "^18.2.12",
+        "@angular/compiler-cli": "^18.2.12",
+        "@angular/platform-browser": "^18.2.12",
+        "@angular/platform-browser-dynamic": "^18.2.12",
         "@types/jasmine": "^5.1.4",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.9.0",
@@ -47,7 +47,7 @@
         "zone.js": "^0.14.10"
       },
       "peerDependencies": {
-        "@angular/core": "^18.2.11"
+        "@angular/core": "^18.2.12"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -65,13 +65,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1802.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.11.tgz",
-      "integrity": "sha512-p+XIc/j51aI83ExNdeZwvkm1F4wkuKMGUUoj0MVUUi5E6NoiMlXYm6uU8+HbRvPBzGy5+3KOiGp3Fks0UmDSAA==",
+      "version": "0.1802.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.12.tgz",
+      "integrity": "sha512-bepVb2/GtJppYKaeW8yTGE6egmoWZ7zagFDsmBdbF+BYp+HmeoPsclARcdryBPVq68zedyTRdvhWSUTbw1AYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.11",
+        "@angular-devkit/core": "18.2.12",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -81,17 +81,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.11.tgz",
-      "integrity": "sha512-09Ln3NAdlMw/wMLgnwYU5VgWV5TPBEHolZUIvE9D8b6SFWBCowk3B3RWeAMgg7Peuf9SKwqQHBz2b1C7RTP/8g==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.12.tgz",
+      "integrity": "sha512-quVUi7eqTq9OHumQFNl9Y8t2opm8miu4rlYnuF6rbujmmBDvdUvR6trFChueRczl2p5HWqTOr6NPoDGQm8AyNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.11",
-        "@angular-devkit/build-webpack": "0.1802.11",
-        "@angular-devkit/core": "18.2.11",
-        "@angular/build": "18.2.11",
+        "@angular-devkit/architect": "0.1802.12",
+        "@angular-devkit/build-webpack": "0.1802.12",
+        "@angular-devkit/core": "18.2.12",
+        "@angular/build": "18.2.12",
         "@babel/core": "7.25.2",
         "@babel/generator": "7.25.0",
         "@babel/helper-annotate-as-pure": "7.24.7",
@@ -102,7 +102,7 @@
         "@babel/preset-env": "7.25.3",
         "@babel/runtime": "7.25.0",
         "@discoveryjs/json-ext": "0.6.1",
-        "@ngtools/webpack": "18.2.11",
+        "@ngtools/webpack": "18.2.12",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -217,13 +217,13 @@
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1802.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.11.tgz",
-      "integrity": "sha512-G76rNsyn1iQk7qjyr+K4rnDzfalmEswmwXQorypSDGaHYzIDY1SZXMoP4225WMq5fJNBOJrk82FA0PSfnPE+zQ==",
+      "version": "0.1802.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.12.tgz",
+      "integrity": "sha512-0Z3fdbZVRnjYWE2/VYyfy+uieY+6YZyEp4ylzklVkc+fmLNsnz4Zw6cK1LzzcBqAwKIyh1IdW20Cg7o8b0sONA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.11",
+        "@angular-devkit/architect": "0.1802.12",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.11.tgz",
-      "integrity": "sha512-H9P1shRGigORWJHUY2BRa2YurT+DVminrhuaYHsbhXBRsPmgB2Dx/30YLTnC1s5XmR9QIRUCsg/d3kyT1wd5Zg==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.12.tgz",
+      "integrity": "sha512-NtB6ypsaDyPE6/fqWOdfTmACs+yK5RqfH5tStEzWFeeDsIEDYKsJ06ypuRep7qTjYus5Rmttk0Ds+cFgz8JdUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -265,13 +265,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.11.tgz",
-      "integrity": "sha512-efRK3FotTFp4KD5u42jWfXpHUALXB9kJNsWiB4wEImKFH6CN+vjBspJQuLqk2oeBFh/7D2qRMc5P+2tZHM5hdw==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.12.tgz",
+      "integrity": "sha512-mMea9txHbnCX5lXLHlo0RAgfhFHDio45/jMsREM2PA8UtVf2S8ltXz7ZwUrUyMQRv8vaSfn4ijDstF4hDMnRgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.11",
+        "@angular-devkit/core": "18.2.12",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.11",
         "ora": "5.4.1",
@@ -385,14 +385,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.11.tgz",
-      "integrity": "sha512-AgirvSCmqUKiDE3C0rl3JA68OkOqQWDKUvjqRHXCkhxldLVOVoeIl87+jBYK/v9gcmk+K+ju+5wbGEfu1FjhiQ==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.12.tgz",
+      "integrity": "sha512-4Ohz+OSILoL+cCAQ4UTiCT5v6pctu3fXNoNpTEUK46OmxELk9jDITO5rNyNS7TxBn9wY69kjX5VcDf7MenquFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.11",
+        "@angular-devkit/architect": "0.1802.12",
         "@babel/core": "7.25.2",
         "@babel/helper-annotate-as-pure": "7.24.7",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -454,18 +454,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.11.tgz",
-      "integrity": "sha512-0JI1xjOLRemBPjdT/yVlabxc3Zkjqa/lhvVxxVC1XhKoW7yGxIGwNrQ4pka4CcQtCuktO6KPMmTGIu8YgC3cpw==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.12.tgz",
+      "integrity": "sha512-xhuZ/b7IhqNw1MgXf+arWf4x+GfUSt/IwbdWU4+CO8A7h0Y46zQywouP/KUK3cMQZfVdHdciTBvlpF3vFacA6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.11",
-        "@angular-devkit/core": "18.2.11",
-        "@angular-devkit/schematics": "18.2.11",
+        "@angular-devkit/architect": "0.1802.12",
+        "@angular-devkit/core": "18.2.12",
+        "@angular-devkit/schematics": "18.2.12",
         "@inquirer/prompts": "5.3.8",
         "@listr2/prompt-adapter-inquirer": "2.0.15",
-        "@schematics/angular": "18.2.11",
+        "@schematics/angular": "18.2.12",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "4.1.3",
         "jsonc-parser": "3.3.1",
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.11.tgz",
-      "integrity": "sha512-bamJeISl2zUlvjPYebQWazUjhjXU9nrot42cQJng94SkvNENT9LTWfPYgc+Bd972Kg+31jG4H41rgFNs7zySmw==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.12.tgz",
+      "integrity": "sha512-gI5o8Bccsi8ow8Wk2vG4Tw/Rw9LoHEA9j8+qHKNR/55SCBsz68Syg310dSyxy+sApJO2WiqIadr5VP36dlSUFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -500,14 +500,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.11",
+        "@angular/core": "18.2.12",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.11.tgz",
-      "integrity": "sha512-PSVL1YXUhTzkgJNYXiWk9eAZxNV6laQJRGdj9++C1q9m2S9/GlehZGzkt5GtC5rlUweJucCNvBC1+2D5FAt9vA==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.12.tgz",
+      "integrity": "sha512-D5d5dLrjQal5DbAXJJNSsCC3UxzjOI2wbc+Iv+LOpRM1gpNwuYfZMX5W7cj62Ce4G2++78CJSppdKBp8D4HErQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -517,7 +517,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.11"
+        "@angular/core": "18.2.12"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -526,9 +526,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.11.tgz",
-      "integrity": "sha512-YJlAOiXZUYP6/RK9isu5AOucmNZhFB9lpY/beMzkkWgDku+va8szm4BZbLJFz176IUteyLWF3IP4aE7P9OBlXw==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.12.tgz",
+      "integrity": "sha512-IWimTNq5Q+i2Wxev6HLqnN4iYbPvLz04W1BBycT1LfGUsHcjFYLuUqbeUzHbk2snmBAzXkixgVpo8SF6P4Y5Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -550,7 +550,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "18.2.11",
+        "@angular/compiler": "18.2.12",
         "typescript": ">=5.4 <5.6"
       }
     },
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.11.tgz",
-      "integrity": "sha512-/AGAFyZN8KR+kW5FUFCCBCj3qHyDDum7G0lJe5otrT9AqF6+g7PjF8yLha/6wPkJG7ri5xGLhini1sEivVeq/g==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.12.tgz",
+      "integrity": "sha512-wCf/OObwS6bpM60rk6bpMpCRGp0DlMLB1WNAMtfcaPNyqimVV5Bm98mWRhkOuRyvU3fU7iHhM/10ePVaoyu9+A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.11.tgz",
-      "integrity": "sha512-bzcP0QdPT/ncTxOx0t7901z5m0wDmkraTo/es4g8reV6VK9Ptv0QDuD8aDvrHh7sLCX5VgwDF9ohc6S2TpYUCA==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.12.tgz",
+      "integrity": "sha512-DRSMznuxuecrs+v5BRyd60/R4vjkQtuYUEPfzdo+rqxM83Dmr3PGtnqPRgd5oAFUbATxf02hQXijRD27K7rZRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -614,9 +614,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "18.2.11",
-        "@angular/common": "18.2.11",
-        "@angular/core": "18.2.11"
+        "@angular/animations": "18.2.12",
+        "@angular/common": "18.2.12",
+        "@angular/core": "18.2.12"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.11.tgz",
-      "integrity": "sha512-a30U4ZdTZSvL17xWwOq6xh9ToCDP2K7/j1HTJFREObbuAtZTa/6IVgBUM6oOMNQ43kHkT6Mr9Emkgf9iGtWwfw==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-18.2.12.tgz",
+      "integrity": "sha512-dv1QEjYpcFno6+oUeGEDRWpB5g2Ufb0XkUbLJQIgrOk1Qbyzb8tmpDpTjok8jcKdquigMRWolr6Y1EOicfRlLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -637,10 +637,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "18.2.11",
-        "@angular/compiler": "18.2.11",
-        "@angular/core": "18.2.11",
-        "@angular/platform-browser": "18.2.11"
+        "@angular/common": "18.2.12",
+        "@angular/compiler": "18.2.12",
+        "@angular/core": "18.2.12",
+        "@angular/platform-browser": "18.2.12"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3873,9 +3873,9 @@
       ]
     },
     "node_modules/@ngtools/webpack": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.11.tgz",
-      "integrity": "sha512-iTdUGJ5O7yMm1DyCzyoMDMxBJ68emUSSXPWbQzEEdcqmtifRebn+VAq4vHN8OmtGM1mtuKeLEsbiZP8ywrw7Ug==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.12.tgz",
+      "integrity": "sha512-FFJAwtWbtpncMOVNuULPBwFJB7GSjiUwO93eGTzRp8O4EPQ8lCQeFbezQm/NP34+T0+GBLGzPSuQT+muob8YKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4538,14 +4538,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "18.2.11",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.11.tgz",
-      "integrity": "sha512-jT54mc9+hPOwie9bji/g2krVuK1kkNh2PNFGwfgCg3Ofmt3hcyOBai1DKuot5uLTX4VCCbvfwiVR/hJniQl2SA==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.12.tgz",
+      "integrity": "sha512-sIoeipsisK5eTLW3XuNZYcal83AfslBbgI7LnV+3VrXwpasKPGHwo2ZdwhCd2IXAkuJ02Iyu7MyV0aQRM9i/3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.11",
-        "@angular-devkit/schematics": "18.2.11",
+        "@angular-devkit/core": "18.2.12",
+        "@angular-devkit/schematics": "18.2.12",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -4881,9 +4881,9 @@
       "license": "MIT"
     },
     "node_modules/@types/qs": {
-      "version": "6.9.16",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
-      "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
+      "version": "6.9.17",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
+      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13769,9 +13769,9 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
-      "integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14065,9 +14065,9 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -17678,9 +17678,9 @@
       }
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "dev": true,
       "funding": [
         {
@@ -17699,7 +17699,7 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^18.2.11"
+    "@angular/core": "^18.2.12"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.2.11",
+    "@angular-devkit/build-angular": "^18.2.12",
     "@angular-eslint/builder": "^18.4.0",
     "@angular-eslint/eslint-plugin": "^18.4.0",
     "@angular-eslint/eslint-plugin-template": "^18.4.0",
     "@angular-eslint/schematics": "^18.4.0",
     "@angular-eslint/template-parser": "^18.4.0",
-    "@angular/cli": "^18.2.11",
-    "@angular/common": "^18.2.11",
-    "@angular/compiler": "^18.2.11",
-    "@angular/compiler-cli": "^18.2.11",
-    "@angular/platform-browser": "^18.2.11",
-    "@angular/platform-browser-dynamic": "^18.2.11",
+    "@angular/cli": "^18.2.12",
+    "@angular/common": "^18.2.12",
+    "@angular/compiler": "^18.2.12",
+    "@angular/compiler-cli": "^18.2.12",
+    "@angular/platform-browser": "^18.2.12",
+    "@angular/platform-browser-dynamic": "^18.2.12",
     "@types/jasmine": "^5.1.4",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.9.0",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 37 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            18.2.11 -> 18.2.12       ng update @angular/cli
      @angular/core                           18.2.11 -> 18.2.12       ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>