### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^19.0.4",
-        "@angular/cli": "^19.0.4",
-        "@angular/common": "^19.0.3",
-        "@angular/compiler": "^19.0.3",
-        "@angular/compiler-cli": "^19.0.3",
-        "@angular/platform-browser": "^19.0.3",
-        "@angular/platform-browser-dynamic": "^19.0.3",
+        "@angular-devkit/build-angular": "^19.0.5",
+        "@angular/cli": "^19.0.5",
+        "@angular/common": "^19.0.4",
+        "@angular/compiler": "^19.0.4",
+        "@angular/compiler-cli": "^19.0.4",
+        "@angular/platform-browser": "^19.0.4",
+        "@angular/platform-browser-dynamic": "^19.0.4",
         "@types/jasmine": "^5.1.5",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.10.2",
@@ -42,7 +42,7 @@
         "zone.js": "^0.15.0"
       },
       "peerDependencies": {
-        "@angular/core": "^19.0.3"
+        "@angular/core": "^19.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -58,13 +58,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1900.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1900.4.tgz",
-      "integrity": "sha512-9XwZ21BPYS2vGOOwVB40fsMyuwJT0H1lWaAMo8Umwi6XbKBVfaWbEhjtR9dlarrySKtFuTz9hmTZkIXHLjXPdA==",
+      "version": "0.1900.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1900.5.tgz",
+      "integrity": "sha512-JxgoIxwGw3QNj6e70d04g5yJ8ZK0g/my22UK0TlRJRbYcfFQr8pL7u3wq77iNlgeHMDwBskZEf4TEZOVSbm7mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.0.4",
+        "@angular-devkit/core": "19.0.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.4.tgz",
-      "integrity": "sha512-+imxIj1JLr2hbUYQePHgkTUKr0VmlxNSZvIREcCWtXUcdCypiwhJAtGXv6MfpB4hAx+FJZYEpVWeLwYOS/gW0A==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
+      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -136,17 +136,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.0.4.tgz",
-      "integrity": "sha512-n7fcRdNB7ed5j6aZI+qPI/1LylFv1OiRNgBIeJxX3HEmzQxsHHLcxWog2yZK2Fvw3390xFx/VjZaklITj6tBFA==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.0.5.tgz",
+      "integrity": "sha512-Z8GcTBsDGKPIKWtLoRVuss/oGytRaVXZSsXzfCapWjggwuN0B2b26Ms0kfU0kIWRfEzz38wKwug/1l86Q9HqNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1900.4",
-        "@angular-devkit/build-webpack": "0.1900.4",
-        "@angular-devkit/core": "19.0.4",
-        "@angular/build": "19.0.4",
+        "@angular-devkit/architect": "0.1900.5",
+        "@angular-devkit/build-webpack": "0.1900.5",
+        "@angular-devkit/core": "19.0.5",
+        "@angular/build": "19.0.5",
         "@babel/core": "7.26.0",
         "@babel/generator": "7.26.2",
         "@babel/helper-annotate-as-pure": "7.25.9",
@@ -157,7 +157,7 @@
         "@babel/preset-env": "7.26.0",
         "@babel/runtime": "7.26.0",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "19.0.4",
+        "@ngtools/webpack": "19.0.5",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -211,7 +211,7 @@
         "@angular/localize": "^19.0.0",
         "@angular/platform-server": "^19.0.0",
         "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.0.4",
+        "@angular/ssr": "^19.0.5",
         "@web/test-runner": "^0.19.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.4.tgz",
-      "integrity": "sha512-+imxIj1JLr2hbUYQePHgkTUKr0VmlxNSZvIREcCWtXUcdCypiwhJAtGXv6MfpB4hAx+FJZYEpVWeLwYOS/gW0A==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
+      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -324,13 +324,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1900.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1900.4.tgz",
-      "integrity": "sha512-eovr5Am8EwxF7d/y0Hbfz/KYWnOXXVXVwquPUcg8JBI19lLbfctz4+71Vjz2qGroijr2FlZztRpmhd498SLt/A==",
+      "version": "0.1900.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1900.5.tgz",
+      "integrity": "sha512-SWrXxVS0u9RXq3bz1+rKfH79nYiqPL9qdJt4lAhTo5O+Uc+qEHLctLvkOYCJHqezLblJG2nGBhHTB0EBmi8pLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1900.4",
+        "@angular-devkit/architect": "0.1900.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -344,13 +344,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.0.4.tgz",
-      "integrity": "sha512-2r6Qs4N5NSPho+qzegCYS8kIgylXyH4DHaS7HJ5+4XvM1I8V8AII8payLWkUK0i29XufVoD5XfPUFnjxZrBfYQ==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.0.5.tgz",
+      "integrity": "sha512-dhLVBVb0ECfcIP59azoD/5lJMSMU//bo1LEbuE0VrFA9orVxQhgilNuZeVXBr5sOll1PFjxs/fqyX8sAH9xQYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.0.4",
+        "@angular-devkit/core": "19.0.5",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.12",
         "ora": "5.4.1",
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.4.tgz",
-      "integrity": "sha512-+imxIj1JLr2hbUYQePHgkTUKr0VmlxNSZvIREcCWtXUcdCypiwhJAtGXv6MfpB4hAx+FJZYEpVWeLwYOS/gW0A==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
+      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -648,14 +648,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.0.4.tgz",
-      "integrity": "sha512-ubsNjLb54VkZwcPQ21Ke8aAHiIrRIcv7gG3R6/6XOoWeK1K2+tsv8bnO4mz5cHgzWOspLOT7FDC83NJjrKX3Nw==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.0.5.tgz",
+      "integrity": "sha512-/4msIXebFfDWcsyYGDzcxrhn1G1bWVTVbLYqkDXDVYFTqWRpBA8UtQ6eLM8FrJqrHw9e/1cxkqBNsR0tkDJ9FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1900.4",
+        "@angular-devkit/architect": "0.1900.5",
         "@babel/core": "7.26.0",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -694,7 +694,7 @@
         "@angular/localize": "^19.0.0",
         "@angular/platform-server": "^19.0.0",
         "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.0.4",
+        "@angular/ssr": "^19.0.5",
         "less": "^4.2.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^2.0.0 || ^3.0.0",
@@ -725,18 +725,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.0.4.tgz",
-      "integrity": "sha512-jxnD9qkhelcRMCrHDCxNsWgn6HQCvMIj8uI0T2eB9Vy93q2YWUo/fWl2Sy4gFlR+VNeF+1hYhPLb/vqLLzjWuA==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.0.5.tgz",
+      "integrity": "sha512-AalLr1EbgJqBbzk+5ZtXwg6wCwLlRLd+CRrZZcC6QSee69mfsU9jEP2KFlMAecajOCqAGK3H4ZRiTZNeQ3y5AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1900.4",
-        "@angular-devkit/core": "19.0.4",
-        "@angular-devkit/schematics": "19.0.4",
+        "@angular-devkit/architect": "0.1900.5",
+        "@angular-devkit/core": "19.0.5",
+        "@angular-devkit/schematics": "19.0.5",
         "@inquirer/prompts": "7.1.0",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.0.4",
+        "@schematics/angular": "19.0.5",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.4.tgz",
-      "integrity": "sha512-+imxIj1JLr2hbUYQePHgkTUKr0VmlxNSZvIREcCWtXUcdCypiwhJAtGXv6MfpB4hAx+FJZYEpVWeLwYOS/gW0A==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
+      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.0.3.tgz",
-      "integrity": "sha512-YyBVZU+LQ38R+/U5vF/b1T3muROKpR0kkupMw7VKnGhQfgrRX5Dk3H2nr9ritt0zPc7TOUuQSlHMf3QWah2GDg==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.0.4.tgz",
+      "integrity": "sha512-SBWraO5NVZa/QJPrVbk3IsUmZQDriYBvqYuZFJaI/UTbhcAedNRsLDbKHtOYrHHx6K1saPXSQCufWgFo30lEqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -833,14 +833,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.0.3",
+        "@angular/core": "19.0.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.0.3.tgz",
-      "integrity": "sha512-cxtK4SlHAPstcXfjwOaoR1dAszrzo2iDF8ZiihbZPgKUG3m27qIU3Lp5XBgxfZPlO4jh6TXkWznY7f6Tyxkb0Q==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.0.4.tgz",
+      "integrity": "sha512-DWeP7lnR8L8W/jtmO9oWEGC9JcFE+GCLrsHm8cJN1a4jf9JA1OB8UsPdqxS/JHJJ8GWk5U1ivpTzxKBpXx6ShA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -850,7 +850,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.0.3"
+        "@angular/core": "19.0.4"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.0.3.tgz",
-      "integrity": "sha512-nayLcC3hSHoGKXCZInMdFcIZJEHYkEGNsdAutgCMuSj+lXCGuRUysuGC0rGzJc2R6nhgfaLJnO8T/O5acqaqdA==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.0.4.tgz",
+      "integrity": "sha512-D26HwIYNuvo39Jnimv3VguBpMZkpGf1zAS3ZE9atfk1AQOew7KSFnqbSm1IRHiTj99cqnBE068q1zZnXg+3mEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -883,7 +883,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.0.3",
+        "@angular/compiler": "19.0.4",
         "typescript": ">=5.5 <5.7"
       }
     },
@@ -914,9 +914,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.0.3.tgz",
-      "integrity": "sha512-WM844gDzrbHtcM2TJB9DmfCmenUYyNSI6h924CeppDW5oG8ShinQGiWNjF5oI6EZ4tG60uK3QvCm3kjr1dmbOA==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.0.4.tgz",
+      "integrity": "sha512-eoLixL8+03HpMIrmbL9lX+PAEw/fJSGshUH99IN9ZgCDEWeAlORg3U5RQEEh59ovelGfTn/sNaYhWsLVoBUIYQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -931,9 +931,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.0.3.tgz",
-      "integrity": "sha512-vggWHSzOsCpYqnGq5IIN+n7xdEvXfgUGaMdgzPhFMTsnlMTUs5+VEFl9tX9FANHkXKB5S1RttVyvEXRqJM9ncQ==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.0.4.tgz",
+      "integrity": "sha512-/PRr7kLVVqNFqAkw+SK8RwqE479qCcUyuw6GOHtGabt3ZfQKSbx+pTioVrZFEy5pTBMslCPV5q3I+wGRG7/nyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -943,9 +943,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.0.3",
-        "@angular/common": "19.0.3",
-        "@angular/core": "19.0.3"
+        "@angular/animations": "19.0.4",
+        "@angular/common": "19.0.4",
+        "@angular/core": "19.0.4"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.0.3.tgz",
-      "integrity": "sha512-gFh+QN7JvepnD3mS0XmOtDmfY8h5sSkk2/guesE2A68Na8q+M3fGZlz7I37tCXToLth5us1X0Gi0UPCSESc4SA==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.0.4.tgz",
+      "integrity": "sha512-tO1WeGN7nORU/377t0VClyPin7JtURqld6+zuYlDWjr/wKHDS1OM7rwbOYFMxHmutWGjANwG6BP8gWXgGsHJeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -966,10 +966,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.0.3",
-        "@angular/compiler": "19.0.3",
-        "@angular/core": "19.0.3",
-        "@angular/platform-browser": "19.0.3"
+        "@angular/common": "19.0.4",
+        "@angular/compiler": "19.0.4",
+        "@angular/core": "19.0.4",
+        "@angular/platform-browser": "19.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3750,9 +3750,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.0.4.tgz",
-      "integrity": "sha512-N3WCbQz5ipdAZoSWHNf81RLET6+isq35+GZu9u0StpFtJCpXAmRRAv4vdMUYL7DLOzRmvEgwww6Rd5AwGeLFSw==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.0.5.tgz",
+      "integrity": "sha512-T8BJQHbGySRkR4JYLcH3YIscbRJI/GNWidNHL5GzRG+3i8Z6XmR0KLTIEoZGaCLpTGR8hcCG5Lfj/uF5pa4Yww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4442,14 +4442,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.0.4.tgz",
-      "integrity": "sha512-1fXBtkA/AjgMPxHLpGlw7NuT/wggCqAwBAmDnSiRnBBV7Pgs/tHorLgh7A9eoUi3c8CYCuAh8zqWNyjBGGigOQ==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.0.5.tgz",
+      "integrity": "sha512-4nBJZF8HvSdj/RoyIixAfOuKEQaEBsEBtohIow8iHX1wcLax558d70O/ZM6EOh2FQxmEaxUe1x4KwBQIha8RxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.0.4",
-        "@angular-devkit/schematics": "19.0.4",
+        "@angular-devkit/core": "19.0.5",
+        "@angular-devkit/schematics": "19.0.5",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -4459,9 +4459,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.4.tgz",
-      "integrity": "sha512-+imxIj1JLr2hbUYQePHgkTUKr0VmlxNSZvIREcCWtXUcdCypiwhJAtGXv6MfpB4hAx+FJZYEpVWeLwYOS/gW0A==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
+      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^19.0.3"
+    "@angular/core": "^19.0.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^19.0.4",
-    "@angular/cli": "^19.0.4",
-    "@angular/common": "^19.0.3",
-    "@angular/compiler": "^19.0.3",
-    "@angular/compiler-cli": "^19.0.3",
-    "@angular/platform-browser": "^19.0.3",
-    "@angular/platform-browser-dynamic": "^19.0.3",
+    "@angular-devkit/build-angular": "^19.0.5",
+    "@angular/cli": "^19.0.5",
+    "@angular/common": "^19.0.4",
+    "@angular/compiler": "^19.0.4",
+    "@angular/compiler-cli": "^19.0.4",
+    "@angular/platform-browser": "^19.0.4",
+    "@angular/platform-browser-dynamic": "^19.0.4",
     "@types/jasmine": "^5.1.5",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.10.2",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 32 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       19.0.4 -> 19.0.5         ng update @angular/cli
      @angular/core                      19.0.3 -> 19.0.4         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>