### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^19.0.5",
-        "@angular/cli": "^19.0.5",
-        "@angular/common": "^19.0.4",
-        "@angular/compiler": "^19.0.4",
-        "@angular/compiler-cli": "^19.0.4",
-        "@angular/platform-browser": "^19.0.4",
-        "@angular/platform-browser-dynamic": "^19.0.4",
+        "@angular-devkit/build-angular": "^19.0.6",
+        "@angular/cli": "^19.0.6",
+        "@angular/common": "^19.0.5",
+        "@angular/compiler": "^19.0.5",
+        "@angular/compiler-cli": "^19.0.5",
+        "@angular/platform-browser": "^19.0.5",
+        "@angular/platform-browser-dynamic": "^19.0.5",
         "@types/jasmine": "^5.1.5",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.10.2",
@@ -42,7 +42,7 @@
         "zone.js": "^0.15.0"
       },
       "peerDependencies": {
-        "@angular/core": "^19.0.4"
+        "@angular/core": "^19.0.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -58,13 +58,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1900.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1900.5.tgz",
-      "integrity": "sha512-JxgoIxwGw3QNj6e70d04g5yJ8ZK0g/my22UK0TlRJRbYcfFQr8pL7u3wq77iNlgeHMDwBskZEf4TEZOVSbm7mw==",
+      "version": "0.1900.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1900.6.tgz",
+      "integrity": "sha512-w11bAXQnNWBawTJfQPjvaTRrzrqsOUm9tK9WNvaia/xjiRFpmO0CfmKtn3axNSEJM8jb/czaNQrgTwG+TGc/8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.0.5",
+        "@angular-devkit/core": "19.0.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
-      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.6.tgz",
+      "integrity": "sha512-WUWJhzQDsovfMY6jtb9Ktz/5sJszsaErj+XV2aXab85f1OweI/Iv2urPZnJwUSilvVN5Ok/fy3IJ6SuihK4Ceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -102,9 +102,9 @@
       }
     },
     "node_modules/@angular-devkit/architect/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -136,17 +136,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.0.5.tgz",
-      "integrity": "sha512-Z8GcTBsDGKPIKWtLoRVuss/oGytRaVXZSsXzfCapWjggwuN0B2b26Ms0kfU0kIWRfEzz38wKwug/1l86Q9HqNA==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.0.6.tgz",
+      "integrity": "sha512-dWTAsE6BSI8z0xglQdYBdqTBwg1Q+RWE3OrmlGs+520Dcoq/F0Z41Y1F3MiuHuQPdDAIQr88iB0APkIRW4clMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1900.5",
-        "@angular-devkit/build-webpack": "0.1900.5",
-        "@angular-devkit/core": "19.0.5",
-        "@angular/build": "19.0.5",
+        "@angular-devkit/architect": "0.1900.6",
+        "@angular-devkit/build-webpack": "0.1900.6",
+        "@angular-devkit/core": "19.0.6",
+        "@angular/build": "19.0.6",
         "@babel/core": "7.26.0",
         "@babel/generator": "7.26.2",
         "@babel/helper-annotate-as-pure": "7.25.9",
@@ -157,7 +157,7 @@
         "@babel/preset-env": "7.26.0",
         "@babel/runtime": "7.26.0",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "19.0.5",
+        "@ngtools/webpack": "19.0.6",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -211,7 +211,7 @@
         "@angular/localize": "^19.0.0",
         "@angular/platform-server": "^19.0.0",
         "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.0.5",
+        "@angular/ssr": "^19.0.6",
         "@web/test-runner": "^0.19.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
-      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.6.tgz",
+      "integrity": "sha512-WUWJhzQDsovfMY6jtb9Ktz/5sJszsaErj+XV2aXab85f1OweI/Iv2urPZnJwUSilvVN5Ok/fy3IJ6SuihK4Ceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -290,9 +290,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -324,13 +324,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1900.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1900.5.tgz",
-      "integrity": "sha512-SWrXxVS0u9RXq3bz1+rKfH79nYiqPL9qdJt4lAhTo5O+Uc+qEHLctLvkOYCJHqezLblJG2nGBhHTB0EBmi8pLg==",
+      "version": "0.1900.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1900.6.tgz",
+      "integrity": "sha512-WehtVrbBow4fc7hsaUKb+BZ6MDE5lO98/tgv7GR5PkRdGKnyLA0pW1AfPLJJQDgcaKjneramMhDFNc1eGSX0mQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1900.5",
+        "@angular-devkit/architect": "0.1900.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -344,13 +344,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.0.5.tgz",
-      "integrity": "sha512-dhLVBVb0ECfcIP59azoD/5lJMSMU//bo1LEbuE0VrFA9orVxQhgilNuZeVXBr5sOll1PFjxs/fqyX8sAH9xQYw==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.0.6.tgz",
+      "integrity": "sha512-R9hlHfAh1HKoIWgnYJlOEKhUezhTNl0fpUmHxG2252JSY5FLRxmYArTtJYYmbNdBbsBLNg3UHyM/GBPvJSA3NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.0.5",
+        "@angular-devkit/core": "19.0.6",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.12",
         "ora": "5.4.1",
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
-      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.6.tgz",
+      "integrity": "sha512-WUWJhzQDsovfMY6jtb9Ktz/5sJszsaErj+XV2aXab85f1OweI/Iv2urPZnJwUSilvVN5Ok/fy3IJ6SuihK4Ceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -648,14 +648,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.0.5.tgz",
-      "integrity": "sha512-/4msIXebFfDWcsyYGDzcxrhn1G1bWVTVbLYqkDXDVYFTqWRpBA8UtQ6eLM8FrJqrHw9e/1cxkqBNsR0tkDJ9FQ==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.0.6.tgz",
+      "integrity": "sha512-KEVNLgTZUF2dfpOYQn+yR2HONHUTxq/2rFVhiK9qAvrm/m+uKJNEXx7hGtbRyoqenZff4ScJq+7feITUldfX8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1900.5",
+        "@angular-devkit/architect": "0.1900.6",
         "@babel/core": "7.26.0",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -694,7 +694,7 @@
         "@angular/localize": "^19.0.0",
         "@angular/platform-server": "^19.0.0",
         "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.0.5",
+        "@angular/ssr": "^19.0.6",
         "less": "^4.2.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^2.0.0 || ^3.0.0",
@@ -725,18 +725,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.0.5.tgz",
-      "integrity": "sha512-AalLr1EbgJqBbzk+5ZtXwg6wCwLlRLd+CRrZZcC6QSee69mfsU9jEP2KFlMAecajOCqAGK3H4ZRiTZNeQ3y5AA==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.0.6.tgz",
+      "integrity": "sha512-ZEHhgRRVIdn10dbsAjB8TE9Co32hfuL9/im5Jcfa1yrn6KJefmigz6KN8Xu7FXMH5FkdqfQ11QpLBxJSPb9aww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1900.5",
-        "@angular-devkit/core": "19.0.5",
-        "@angular-devkit/schematics": "19.0.5",
+        "@angular-devkit/architect": "0.1900.6",
+        "@angular-devkit/core": "19.0.6",
+        "@angular-devkit/schematics": "19.0.6",
         "@inquirer/prompts": "7.1.0",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.0.5",
+        "@schematics/angular": "19.0.6",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
-      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.6.tgz",
+      "integrity": "sha512-WUWJhzQDsovfMY6jtb9Ktz/5sJszsaErj+XV2aXab85f1OweI/Iv2urPZnJwUSilvVN5Ok/fy3IJ6SuihK4Ceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -787,9 +787,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.0.4.tgz",
-      "integrity": "sha512-SBWraO5NVZa/QJPrVbk3IsUmZQDriYBvqYuZFJaI/UTbhcAedNRsLDbKHtOYrHHx6K1saPXSQCufWgFo30lEqw==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.0.5.tgz",
+      "integrity": "sha512-fFK+euCj1AjBHBCpj9VnduMSeqoMRhZZHbhPYiND7tucRRJ8vwGU0sYK2KI/Ko+fsrNIXL/0O4F36jVPl09Smg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -833,14 +833,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.0.4",
+        "@angular/core": "19.0.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.0.4.tgz",
-      "integrity": "sha512-DWeP7lnR8L8W/jtmO9oWEGC9JcFE+GCLrsHm8cJN1a4jf9JA1OB8UsPdqxS/JHJJ8GWk5U1ivpTzxKBpXx6ShA==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.0.5.tgz",
+      "integrity": "sha512-S8ku5Ljp0kqX3shfmE9DVo09629jeYJSlBRGbj2Glb92dd+VQZPOz7KxqKRTwmAl7lQIV/+4Lr6G/GVTsoC4vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -850,7 +850,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.0.4"
+        "@angular/core": "19.0.5"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.0.4.tgz",
-      "integrity": "sha512-D26HwIYNuvo39Jnimv3VguBpMZkpGf1zAS3ZE9atfk1AQOew7KSFnqbSm1IRHiTj99cqnBE068q1zZnXg+3mEA==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.0.5.tgz",
+      "integrity": "sha512-KSzuWCTZlvJsoAenxM9cjTOzNM8mrFxDBInj0KVPz7QU83amGS4rcv1pWO/QGYQcErfskcN84TAdMegaRWWCmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -883,7 +883,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.0.4",
+        "@angular/compiler": "19.0.5",
         "typescript": ">=5.5 <5.7"
       }
     },
@@ -914,9 +914,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.0.4.tgz",
-      "integrity": "sha512-eoLixL8+03HpMIrmbL9lX+PAEw/fJSGshUH99IN9ZgCDEWeAlORg3U5RQEEh59ovelGfTn/sNaYhWsLVoBUIYQ==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.0.5.tgz",
+      "integrity": "sha512-Ywc6sPO6G/Y1stfk3y/MallV/h0yzQ0vdOHRWueLrk5kD1DTdbolV4X03Cs3PuVvravgcSVE3nnuuHFuH32emQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -931,9 +931,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.0.4.tgz",
-      "integrity": "sha512-/PRr7kLVVqNFqAkw+SK8RwqE479qCcUyuw6GOHtGabt3ZfQKSbx+pTioVrZFEy5pTBMslCPV5q3I+wGRG7/nyg==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.0.5.tgz",
+      "integrity": "sha512-41+Jo5DEil4Ifvv+UE/p1l9YJtYN+xfhx+/C9cahVgvV5D2q+givyK73d0Mnb6XOfe1q+hoV5lZ+XhQYp21//g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -943,9 +943,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.0.4",
-        "@angular/common": "19.0.4",
-        "@angular/core": "19.0.4"
+        "@angular/animations": "19.0.5",
+        "@angular/common": "19.0.5",
+        "@angular/core": "19.0.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.0.4.tgz",
-      "integrity": "sha512-tO1WeGN7nORU/377t0VClyPin7JtURqld6+zuYlDWjr/wKHDS1OM7rwbOYFMxHmutWGjANwG6BP8gWXgGsHJeg==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.0.5.tgz",
+      "integrity": "sha512-KKFdue/uJVxkWdrntRAXkz+ycp4nD3SuGOH5pPf2svCBxieuHuFlWDi+DYVuFSEpC/ICCmlhrtzIAm44A4qzzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -966,10 +966,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.0.4",
-        "@angular/compiler": "19.0.4",
-        "@angular/core": "19.0.4",
-        "@angular/platform-browser": "19.0.4"
+        "@angular/common": "19.0.5",
+        "@angular/compiler": "19.0.5",
+        "@angular/core": "19.0.5",
+        "@angular/platform-browser": "19.0.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3749,9 +3749,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.0.5.tgz",
-      "integrity": "sha512-T8BJQHbGySRkR4JYLcH3YIscbRJI/GNWidNHL5GzRG+3i8Z6XmR0KLTIEoZGaCLpTGR8hcCG5Lfj/uF5pa4Yww==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.0.6.tgz",
+      "integrity": "sha512-eWrIb0tS1CK6+JvFS4GgTD4fN9TtmApKrlaj3pPQXKXKKd42361ec85fuQQXdb4G8eEEq0vyd/bn4NJllh/3vw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4441,14 +4441,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.0.5.tgz",
-      "integrity": "sha512-4nBJZF8HvSdj/RoyIixAfOuKEQaEBsEBtohIow8iHX1wcLax558d70O/ZM6EOh2FQxmEaxUe1x4KwBQIha8RxA==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.0.6.tgz",
+      "integrity": "sha512-HicclmbW/+mlljU7a4PzbyIWG+7tognoL5LsgMFJQUDzJXHNjRt1riL0vk57o8Pcprnz9FheeWZXO1KRhXkQuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.0.5",
-        "@angular-devkit/schematics": "19.0.5",
+        "@angular-devkit/core": "19.0.6",
+        "@angular-devkit/schematics": "19.0.6",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -4458,9 +4458,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.5.tgz",
-      "integrity": "sha512-njBblpYHmlDI+Jtbub9NEm9RH+SBIFmmsgL9uJB8GxQVSo2qo4+f69nTkijRNN8WNKsSkYoRR9+JSl9QXWbyEA==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.6.tgz",
+      "integrity": "sha512-WUWJhzQDsovfMY6jtb9Ktz/5sJszsaErj+XV2aXab85f1OweI/Iv2urPZnJwUSilvVN5Ok/fy3IJ6SuihK4Ceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4486,9 +4486,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -11673,9 +11673,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.15.0.tgz",
-      "integrity": "sha512-q9MmZXd2rRWHS6GU3WEm3HyiXZyyoA1DqdOhEq0lxPBmKb5S7IAOwX0RgUCwJfqjelDCySa5h8ujOy24LqsWcw==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.15.1.tgz",
+      "integrity": "sha512-ufCzgFwiVnR6R9cCYuvwznJdhdYXEvFl0hpnM4cCtVaVkHuqBR+6fo2sqt1SSMdp+uiHw9GyPZr3OMM5tqjSmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^19.0.4"
+    "@angular/core": "^19.0.5"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^19.0.5",
-    "@angular/cli": "^19.0.5",
-    "@angular/common": "^19.0.4",
-    "@angular/compiler": "^19.0.4",
-    "@angular/compiler-cli": "^19.0.4",
-    "@angular/platform-browser": "^19.0.4",
-    "@angular/platform-browser-dynamic": "^19.0.4",
+    "@angular-devkit/build-angular": "^19.0.6",
+    "@angular/cli": "^19.0.6",
+    "@angular/common": "^19.0.5",
+    "@angular/compiler": "^19.0.5",
+    "@angular/compiler-cli": "^19.0.5",
+    "@angular/platform-browser": "^19.0.5",
+    "@angular/platform-browser-dynamic": "^19.0.5",
     "@types/jasmine": "^5.1.5",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.10.2",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 32 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       19.0.5 -> 19.0.6         ng update @angular/cli
      @angular/core                      19.0.4 -> 19.0.5         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>