### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^19.1.5",
-        "@angular/cli": "^19.1.5",
-        "@angular/common": "^19.1.4",
-        "@angular/compiler": "^19.1.4",
-        "@angular/compiler-cli": "^19.1.4",
-        "@angular/platform-browser": "^19.1.4",
-        "@angular/platform-browser-dynamic": "^19.1.4",
+        "@angular-devkit/build-angular": "^19.1.6",
+        "@angular/cli": "^19.1.6",
+        "@angular/common": "^19.1.5",
+        "@angular/compiler": "^19.1.5",
+        "@angular/compiler-cli": "^19.1.5",
+        "@angular/platform-browser": "^19.1.5",
+        "@angular/platform-browser-dynamic": "^19.1.5",
         "@types/jasmine": "^5.1.5",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.13.1",
-        "angular-eslint": "19.0.2",
+        "angular-eslint": "19.1.0",
         "core-js": "^3.40.0",
         "eslint": "^9.19.0",
         "husky": "^9.1.7",
@@ -42,7 +42,7 @@
         "zone.js": "^0.15.0"
       },
       "peerDependencies": {
-        "@angular/core": "^19.1.4"
+        "@angular/core": "^19.1.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -58,13 +58,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1901.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1901.5.tgz",
-      "integrity": "sha512-zlRudZx34FkFZnSdaQCjxDleHwbQYNLdBFcLi+FBwt0UXqxmhbEIasK3l/3kCOC3QledrjUzVXgouji+OZ/WGQ==",
+      "version": "0.1901.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1901.6.tgz",
+      "integrity": "sha512-JiMrs3T1A7RyF5bh0PLGKDjTR8sa/kh8w63+dW0azcNok30tKjLjwJRPTpePokWefjmRgfKaf/iZ8yfFBnpGpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.1.5",
+        "@angular-devkit/core": "19.1.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.5.tgz",
-      "integrity": "sha512-wGKV+i5mCM/Hd/3CsdrIYcVi5G2Wg/D5941bUDXivrbsqHfKVINxAkI3OI1eaD90VnAL8ICrQEoAhh6ni2Umkg==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.6.tgz",
+      "integrity": "sha512-4s1RpYFGb/yP6OZ1dnYmU7maFYdhZS9pnUHKKiL9rSDhUHkX+VZlf9WFFrHv2RMWg+evrrwPtiFOTMBLShUi8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -136,17 +136,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.1.5.tgz",
-      "integrity": "sha512-ny7ktNOTxaEi6cS3V6XFP5bbJkgiMt3OUNUYLdfdbv4y6wolVlPVHKl+wb4xs6tgbnmx63+e6zGpoDMCRytgcg==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.1.6.tgz",
+      "integrity": "sha512-QZtzkD0PQnBMpIwXyFTa9ZqN2wIEssh8V2VBRXzp0GXOZYvU18ICdZwJCXbRU2Bixwk8mrDALfMfryDWovJkGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1901.5",
-        "@angular-devkit/build-webpack": "0.1901.5",
-        "@angular-devkit/core": "19.1.5",
-        "@angular/build": "19.1.5",
+        "@angular-devkit/architect": "0.1901.6",
+        "@angular-devkit/build-webpack": "0.1901.6",
+        "@angular-devkit/core": "19.1.6",
+        "@angular/build": "19.1.6",
         "@babel/core": "7.26.0",
         "@babel/generator": "7.26.3",
         "@babel/helper-annotate-as-pure": "7.25.9",
@@ -157,7 +157,7 @@
         "@babel/preset-env": "7.26.0",
         "@babel/runtime": "7.26.0",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "19.1.5",
+        "@ngtools/webpack": "19.1.6",
         "@vitejs/plugin-basic-ssl": "1.2.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -211,7 +211,7 @@
         "@angular/localize": "^19.0.0",
         "@angular/platform-server": "^19.0.0",
         "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.1.5",
+        "@angular/ssr": "^19.1.6",
         "@web/test-runner": "^0.19.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.5.tgz",
-      "integrity": "sha512-wGKV+i5mCM/Hd/3CsdrIYcVi5G2Wg/D5941bUDXivrbsqHfKVINxAkI3OI1eaD90VnAL8ICrQEoAhh6ni2Umkg==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.6.tgz",
+      "integrity": "sha512-4s1RpYFGb/yP6OZ1dnYmU7maFYdhZS9pnUHKKiL9rSDhUHkX+VZlf9WFFrHv2RMWg+evrrwPtiFOTMBLShUi8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -324,13 +324,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1901.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1901.5.tgz",
-      "integrity": "sha512-UxEoF7F8L1GpH/N4me7VGe5ZPfxIiVHyhw5/ck3rcVbT6YD22/GYFGSJRGYP+D7LLTJ7OOQvfD6Bc/q62HhWvA==",
+      "version": "0.1901.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1901.6.tgz",
+      "integrity": "sha512-QNcc1XrmkyPuUBn0OGZjUAZZiKstaEHWkk1lSXN2YqRasGcoQjZdKZC3/Xl6ng/A4WjNSFFpImSIiSRI8xd0Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1901.5",
+        "@angular-devkit/architect": "0.1901.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -344,13 +344,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.1.5.tgz",
-      "integrity": "sha512-8QjOlO2CktcTT0TWcaABea2xSePxoPKaZu96+6gc8oZzj/y8DbdGiO9mRvIac9+m4hiZI41Cqm1W+yMsCzYMkA==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.1.6.tgz",
+      "integrity": "sha512-6ljZSVTFqnk0utnXLLd82wM6nj68984n5gfrpT1PlOff6MHHNH2YCfwNSlwg6Q5UfDxhEDIT9/MTLnXd6znIRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.1.5",
+        "@angular-devkit/core": "19.1.6",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.5.tgz",
-      "integrity": "sha512-wGKV+i5mCM/Hd/3CsdrIYcVi5G2Wg/D5941bUDXivrbsqHfKVINxAkI3OI1eaD90VnAL8ICrQEoAhh6ni2Umkg==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.6.tgz",
+      "integrity": "sha512-4s1RpYFGb/yP6OZ1dnYmU7maFYdhZS9pnUHKKiL9rSDhUHkX+VZlf9WFFrHv2RMWg+evrrwPtiFOTMBLShUi8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -425,10 +425,11 @@
       }
     },
     "node_modules/@angular-eslint/builder": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-19.0.2.tgz",
-      "integrity": "sha512-BdmMSndQt2fSBiTVniskUcUpQaeweUapbsL0IDfQ7a13vL0NVXpc3K89YXuVE/xsb08uHtqphuwxPAAj6kX3OA==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-19.1.0.tgz",
+      "integrity": "sha512-LWdQMTES/7GySlpTNFJn3k33ZGmjjWlHI/+IHV7B3xHQ9hj4MPK4ACmE/PNOAIQ9LwQm7sKS+3cTMxOZQ/cvSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": ">= 0.1900.0 < 0.2000.0",
         "@angular-devkit/core": ">= 19.0.0 < 20.0.0"
@@ -439,10 +440,11 @@
       }
     },
     "node_modules/@angular-eslint/builder/node_modules/@angular-devkit/core": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.4.tgz",
-      "integrity": "sha512-+imxIj1JLr2hbUYQePHgkTUKr0VmlxNSZvIREcCWtXUcdCypiwhJAtGXv6MfpB4hAx+FJZYEpVWeLwYOS/gW0A==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.6.tgz",
+      "integrity": "sha512-4s1RpYFGb/yP6OZ1dnYmU7maFYdhZS9pnUHKKiL9rSDhUHkX+VZlf9WFFrHv2RMWg+evrrwPtiFOTMBLShUi8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
@@ -466,10 +468,11 @@
       }
     },
     "node_modules/@angular-eslint/builder/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -483,14 +486,15 @@
       }
     },
     "node_modules/@angular-eslint/builder/node_modules/readdirp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 14.18.0"
       },
       "funding": {
         "type": "individual",
@@ -498,19 +502,21 @@
       }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-19.0.2.tgz",
-      "integrity": "sha512-HPmp92r70SNO/0NdIaIhxrgVSpomqryuUk7jszvNRtu+OzYCJGcbLhQD38T3dbBWT/AV0QXzyzExn6/2ai9fEw==",
-      "dev": true
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-19.1.0.tgz",
+      "integrity": "sha512-HUJyukRvnh8Z9lIdxdblBRuBaPYEVv4iAYZMw3d+dn4rrM27Nt5oh3/zkwYrrPkt36tZdeXdDWrOuz9jgjVN5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.0.2.tgz",
-      "integrity": "sha512-DLuNVVGGFicSThOcMSJyNje+FZSPdG0B3lCBRiqcgKH/16kfM4pV8MobPM7RGK2NhaOmmZ4zzJNwpwWPSgi+Lw==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.1.0.tgz",
+      "integrity": "sha512-TDO0+Ry+oNkxnaLHogKp1k2aey6IkJef5d7hathE4UFT6owjRizltWaRoX6bGw7Qu1yagVLL8L2Se8SddxSPAQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.0.2",
-        "@angular-eslint/utils": "19.0.2"
+        "@angular-eslint/bundled-angular-compiler": "19.1.0",
+        "@angular-eslint/utils": "19.1.0"
       },
       "peerDependencies": {
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
@@ -519,13 +525,14 @@
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.0.2.tgz",
-      "integrity": "sha512-f/OCF9ThnxQ8m0eNYPwnCrySQPhYfCOF6STL7F9LnS8Bs3ZeW3/oT1yLaMIZ1Eg0ogIkgxksMAJZjrJPUPBD1Q==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.1.0.tgz",
+      "integrity": "sha512-bIUizkCY40mnU8oAO1tLV7uN2H/cHf1evLlhpqlb9JYwc5dT2moiEhNDo61OtOgkJmDGNuThAeO9Xk9hGQc7nA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.0.2",
-        "@angular-eslint/utils": "19.0.2",
+        "@angular-eslint/bundled-angular-compiler": "19.1.0",
+        "@angular-eslint/utils": "19.1.0",
         "aria-query": "5.3.2",
         "axobject-query": "4.1.0"
       },
@@ -537,25 +544,27 @@
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-19.0.2.tgz",
-      "integrity": "sha512-wI4SyiAnUCrpigtK6PHRlVWMC9vWljqmlLhbsJV5O5yDajlmRdvgXvSHDefhJm0hSfvZYRXuiAARYv2+QVfnGA==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-19.1.0.tgz",
+      "integrity": "sha512-6S1FjmM7rZxc0u0W0KjqWYOkFQ0q89IGyjPkdUt1a8NwRnWg3VoXp4WYfeuZOjda/FEYuBS/E6rckLAMp0h6Aw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": ">= 19.0.0 < 20.0.0",
         "@angular-devkit/schematics": ">= 19.0.0 < 20.0.0",
-        "@angular-eslint/eslint-plugin": "19.0.2",
-        "@angular-eslint/eslint-plugin-template": "19.0.2",
-        "ignore": "6.0.2",
-        "semver": "7.6.3",
+        "@angular-eslint/eslint-plugin": "19.1.0",
+        "@angular-eslint/eslint-plugin-template": "19.1.0",
+        "ignore": "7.0.3",
+        "semver": "7.7.1",
         "strip-json-comments": "3.1.1"
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.4.tgz",
-      "integrity": "sha512-+imxIj1JLr2hbUYQePHgkTUKr0VmlxNSZvIREcCWtXUcdCypiwhJAtGXv6MfpB4hAx+FJZYEpVWeLwYOS/gW0A==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.6.tgz",
+      "integrity": "sha512-4s1RpYFGb/yP6OZ1dnYmU7maFYdhZS9pnUHKKiL9rSDhUHkX+VZlf9WFFrHv2RMWg+evrrwPtiFOTMBLShUi8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
@@ -579,10 +588,11 @@
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -596,36 +606,52 @@
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/ignore": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
-      "integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/readdirp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 14.18.0"
       },
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@angular-eslint/template-parser": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-19.0.2.tgz",
-      "integrity": "sha512-z3rZd2sBfuYcFf9rGDsB2zz2fbGX8kkF+0ftg9eocyQmzWrlZHFmuw9ha7oP/Mz8gpblyCS/aa1U/Srs6gz0UQ==",
+    "node_modules/@angular-eslint/schematics/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@angular-eslint/template-parser": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-19.1.0.tgz",
+      "integrity": "sha512-wbMi7adlC+uYqZo7NHNBShpNhFJRZsXLqihqvFpAUt1Ei6uDX8HR6MyMEDZ9tUnlqtPVW5nmbedPyLVG7HkjAA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.0.2",
+        "@angular-eslint/bundled-angular-compiler": "19.1.0",
         "eslint-scope": "^8.0.2"
       },
       "peerDependencies": {
@@ -634,12 +660,13 @@
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-19.0.2.tgz",
-      "integrity": "sha512-HotBT8OKr7zCaX1S9k27JuhRiTVIbbYVl6whlb3uwdMIPIWY8iOcEh1tjI4qDPUafpLfR72Dhwi5bO1E17F3/Q==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-19.1.0.tgz",
+      "integrity": "sha512-mcb7hPMH/u6wwUwvsewrmgb9y9NWN6ZacvpUvKlTOxF/jOtTdsu0XfV4YB43sp2A8NWzYzX0Str4c8K1xSmuBQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.0.2"
+        "@angular-eslint/bundled-angular-compiler": "19.1.0"
       },
       "peerDependencies": {
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
@@ -648,15 +675,15 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.1.5.tgz",
-      "integrity": "sha512-byoHcv0/s6WGWap59s43N/eC+4NsviuTnGoj+iR0ayubk8snn6jdkZLbFDfnTuQlTiu4ok8/XcksjzeMkgGyyw==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.1.6.tgz",
+      "integrity": "sha512-6zGdMxMITBj5oVRDKcOL+ufrCSsPLPd5AeRcGkaCYQDshaOmn0UXL4HQylU3nswhVT0dtCd4eDA7fh2dlyVF6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1901.5",
-        "@angular-devkit/core": "19.1.5",
+        "@angular-devkit/architect": "0.1901.6",
+        "@angular-devkit/core": "19.1.6",
         "@babel/core": "7.26.0",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -695,7 +722,7 @@
         "@angular/localize": "^19.0.0",
         "@angular/platform-server": "^19.0.0",
         "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.1.5",
+        "@angular/ssr": "^19.1.6",
         "less": "^4.2.0",
         "ng-packagr": "^19.0.0",
         "postcss": "^8.4.0",
@@ -730,9 +757,9 @@
       }
     },
     "node_modules/@angular/build/node_modules/@angular-devkit/core": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.5.tgz",
-      "integrity": "sha512-wGKV+i5mCM/Hd/3CsdrIYcVi5G2Wg/D5941bUDXivrbsqHfKVINxAkI3OI1eaD90VnAL8ICrQEoAhh6ni2Umkg==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.6.tgz",
+      "integrity": "sha512-4s1RpYFGb/yP6OZ1dnYmU7maFYdhZS9pnUHKKiL9rSDhUHkX+VZlf9WFFrHv2RMWg+evrrwPtiFOTMBLShUi8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -791,19 +818,91 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@angular/cli": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.1.5.tgz",
-      "integrity": "sha512-bedjH3jUcrLgN3GOTTuvjbPcY3Lm0YcYBVY35S1ugI88UK6nbtttiRdgK++Qk2Q8wbg6zuaBAr4ACbfPMsnRaA==",
+    "node_modules/@angular/build/node_modules/vite": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1901.5",
-        "@angular-devkit/core": "19.1.5",
-        "@angular-devkit/schematics": "19.1.5",
+        "esbuild": "^0.24.2",
+        "postcss": "^8.4.49",
+        "rollup": "^4.23.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/cli": {
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.1.6.tgz",
+      "integrity": "sha512-5H9Ri+YNPBnac/h1wTPQ+9mLSXfT1n99FwCtMVy6YnG+akRqOKFmPWB29hkFQAgfXi/MYIj+rQKv+d/9yWJibQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/architect": "0.1901.6",
+        "@angular-devkit/core": "19.1.6",
+        "@angular-devkit/schematics": "19.1.6",
         "@inquirer/prompts": "7.2.1",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.1.5",
+        "@schematics/angular": "19.1.6",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -826,9 +925,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.5.tgz",
-      "integrity": "sha512-wGKV+i5mCM/Hd/3CsdrIYcVi5G2Wg/D5941bUDXivrbsqHfKVINxAkI3OI1eaD90VnAL8ICrQEoAhh6ni2Umkg==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.6.tgz",
+      "integrity": "sha512-4s1RpYFGb/yP6OZ1dnYmU7maFYdhZS9pnUHKKiL9rSDhUHkX+VZlf9WFFrHv2RMWg+evrrwPtiFOTMBLShUi8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -888,9 +987,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.1.4.tgz",
-      "integrity": "sha512-E4MCl13VIotOxmzKQ/UGciPeaRXQgH7ymesEjYVGcT8jmC+qz5dEcoN7L5Jvq9aUsmLBt9MFp/B5QqKCIXMqYA==",
+      "version": "19.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.1.5.tgz",
+      "integrity": "sha512-8jR3c5IBMlfiiHvrO8Y2z8y9n4Moy4mI7bS0eu3hmI3m5Vvrgd2Z4GCaQ/Dt4wCtFxcgSsVXiF+/H0QbVdwulA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -900,14 +999,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.1.4",
+        "@angular/core": "19.1.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.1.4.tgz",
-      "integrity": "sha512-9vGUZ+QhGWvf5dfeILybrh5rvZQtNqS8WumMeX2/vCb0JTA0N4DsL1Sy47HuWcgKBxbmHVUdF5/iufcFaqk2FA==",
+      "version": "19.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.1.5.tgz",
+      "integrity": "sha512-8dhticSq98qZanbPBqLACykR08eHbh9WyXG4VJB7Ru9465DjOd6sRM3gmGDNvNlohh30S4xJzPhVrzYXmIyqiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -917,7 +1016,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.1.4"
+        "@angular/core": "19.1.5"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -926,9 +1025,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.1.4.tgz",
-      "integrity": "sha512-ozJvTUzPOgFqlz69YnV14Ncod+iH0cXZvUKerjw8o+JsixLG2LmJpwQ79Gh4a/ZQmAkAxMAYYK5izCiio8MmTg==",
+      "version": "19.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.1.5.tgz",
+      "integrity": "sha512-7IHfGklqiTsDYjk2SgOi5sG63gZ60LguT7dhMGtUdy+fUyK0KGofE1w74LwPHQ3huCdu3rBp7HZvC0/IsmiYtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -950,7 +1049,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.1.4",
+        "@angular/compiler": "19.1.5",
         "typescript": ">=5.5 <5.8"
       }
     },
@@ -981,9 +1080,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.1.4.tgz",
-      "integrity": "sha512-r3T81lM9evmuW36HA3VAxIJ61M8kirGR8yHoln9fXSnYG8UeJ7JlWEbVRHmVHKOB48VK0bS/VxqN+w9TOq3bZg==",
+      "version": "19.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.1.5.tgz",
+      "integrity": "sha512-N4Uh/jRV2Ksj1iBnhIHkB5hzeiF7J9rhUTiztDPaRT7YpFVt2MKiBXrn52HDcKXPaPFrsZBotbZ6oOMdP4rd5g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -998,9 +1097,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.1.4.tgz",
-      "integrity": "sha512-IoVIvemj7ni6GLDCvwtZhTgMQjPyG+xPW7rASN2RVl9T3uS1fJUpXrh5JzBcCikIj20O2KV9mqt7p4iIXy9jbQ==",
+      "version": "19.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.1.5.tgz",
+      "integrity": "sha512-wqM4OlGncXNmROTS0mpUpnzzG5DsIZi1U0gzQp5bDOknaFFmg2C2ExCi29CwFZfaOeDw135AyXtu4qItfDOW9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1010,9 +1109,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.1.4",
-        "@angular/common": "19.1.4",
-        "@angular/core": "19.1.4"
+        "@angular/animations": "19.1.5",
+        "@angular/common": "19.1.5",
+        "@angular/core": "19.1.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1021,9 +1120,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.1.4.tgz",
-      "integrity": "sha512-r1AM8qkjl63cg46tgOHsVV4URHDctcVpt98DU/d/yN8JAugrx6GA1qOM/HMDspMjEIU4aYcSkUUY6h6uIkYmOQ==",
+      "version": "19.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.1.5.tgz",
+      "integrity": "sha512-mW9Ru5C0/Jg+b2/pWfzfkWmFZ6Exn2J2k+6Unv1Vprh6whF4ch7v5AdBaCuLiK5kUPpQQMHhRz7VY+3mb/dgqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1033,10 +1132,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.1.4",
-        "@angular/compiler": "19.1.4",
-        "@angular/core": "19.1.4",
-        "@angular/platform-browser": "19.1.4"
+        "@angular/common": "19.1.5",
+        "@angular/compiler": "19.1.5",
+        "@angular/core": "19.1.5",
+        "@angular/platform-browser": "19.1.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3876,9 +3975,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.1.5.tgz",
-      "integrity": "sha512-oIpE5Ci/Gl2iZqa0Hs6IOxaXEDHkF/zisHcflzYGkMnYcSFj+wRgYEuBFaHLCwuxQf9OdGu31i05w849i6tY1Q==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.1.6.tgz",
+      "integrity": "sha512-36I/y4KIRWyE35OgZXzYnDCNQ2G3VB/2awj8L3VowDyTP9enJj6V044UGpCNiKOgYerubgMN3gcPIsOzg0pLpg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4598,14 +4697,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.1.5.tgz",
-      "integrity": "sha512-Yks2QD87z2qJhVLi6O0tQDBG4pyX5n5c8BYEyZ+yiThjzIXBRkHjWS1jIFvd/y1+yU/NQFHYG/sy8sVOxfQ9IA==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.1.6.tgz",
+      "integrity": "sha512-TxFp6iHBqXcuyZIW84HA4z3XkAMz3wTw46K3GNhzyfhFTFD0YD+DtaR3MfQ+vcj3YUYu9j44zrB9nchzugR9Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.1.5",
-        "@angular-devkit/schematics": "19.1.5",
+        "@angular-devkit/core": "19.1.6",
+        "@angular-devkit/schematics": "19.1.6",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -4615,9 +4714,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.5.tgz",
-      "integrity": "sha512-wGKV+i5mCM/Hd/3CsdrIYcVi5G2Wg/D5941bUDXivrbsqHfKVINxAkI3OI1eaD90VnAL8ICrQEoAhh6ni2Umkg==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.6.tgz",
+      "integrity": "sha512-4s1RpYFGb/yP6OZ1dnYmU7maFYdhZS9pnUHKKiL9rSDhUHkX+VZlf9WFFrHv2RMWg+evrrwPtiFOTMBLShUi8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5688,18 +5787,19 @@
       }
     },
     "node_modules/angular-eslint": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-19.0.2.tgz",
-      "integrity": "sha512-d8P/Y5+QXOOko1x5W3Pp/p4cr7arXKGHdMAv6jtrqHjsIrlBqZSZY18apKRdTysFjYuKa5G9M3hejtzwXXHNhg==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-19.1.0.tgz",
+      "integrity": "sha512-teauJL5Q6Cc7PBbGG52LF3Lf2s3aI5/Ksoh3MAsJ8Vgsf2cDwBjVxFZqTbAhMYzYp2UzVJ5knXIsammYHCVNBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": ">= 19.0.0 < 20.0.0",
         "@angular-devkit/schematics": ">= 19.0.0 < 20.0.0",
-        "@angular-eslint/builder": "19.0.2",
-        "@angular-eslint/eslint-plugin": "19.0.2",
-        "@angular-eslint/eslint-plugin-template": "19.0.2",
-        "@angular-eslint/schematics": "19.0.2",
-        "@angular-eslint/template-parser": "19.0.2",
+        "@angular-eslint/builder": "19.1.0",
+        "@angular-eslint/eslint-plugin": "19.1.0",
+        "@angular-eslint/eslint-plugin-template": "19.1.0",
+        "@angular-eslint/schematics": "19.1.0",
+        "@angular-eslint/template-parser": "19.1.0",
         "@typescript-eslint/types": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0"
       },
@@ -5854,6 +5954,7 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
       }
@@ -5932,6 +6033,7 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
       }
@@ -12201,7 +12303,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -16254,15 +16358,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
-      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
+      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.24.2",
-        "postcss": "^8.4.49",
-        "rollup": "^4.23.0"
+        "postcss": "^8.5.1",
+        "rollup": "^4.30.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -16323,6 +16428,36 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/void-elements": {

--- a/package.json
+++ b/package.json
@@ -27,20 +27,20 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^19.1.4"
+    "@angular/core": "^19.1.5"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^19.1.5",
-    "@angular/cli": "^19.1.5",
-    "@angular/common": "^19.1.4",
-    "@angular/compiler": "^19.1.4",
-    "@angular/compiler-cli": "^19.1.4",
-    "@angular/platform-browser": "^19.1.4",
-    "@angular/platform-browser-dynamic": "^19.1.4",
+    "@angular-devkit/build-angular": "^19.1.6",
+    "@angular/cli": "^19.1.6",
+    "@angular/common": "^19.1.5",
+    "@angular/compiler": "^19.1.5",
+    "@angular/compiler-cli": "^19.1.5",
+    "@angular/platform-browser": "^19.1.5",
+    "@angular/platform-browser-dynamic": "^19.1.5",
     "@types/jasmine": "^5.1.5",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.13.1",
-    "angular-eslint": "19.0.2",
+    "angular-eslint": "19.1.0",
     "core-js": "^3.40.0",
     "eslint": "^9.19.0",
     "husky": "^9.1.7",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 32 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       19.1.5 -> 19.1.6         ng update @angular/cli
      @angular/core                      19.1.4 -> 19.1.5         ng update @angular/core
      angular-eslint                     19.0.2 -> 19.1.0         ng update angular-eslint
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>