### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^19.2.3",
-        "@angular/cli": "^19.2.3",
-        "@angular/common": "^19.2.2",
-        "@angular/compiler": "^19.2.2",
-        "@angular/compiler-cli": "^19.2.2",
-        "@angular/platform-browser": "^19.2.2",
-        "@angular/platform-browser-dynamic": "^19.2.2",
+        "@angular-devkit/build-angular": "^19.2.4",
+        "@angular/cli": "^19.2.4",
+        "@angular/common": "^19.2.3",
+        "@angular/compiler": "^19.2.3",
+        "@angular/compiler-cli": "^19.2.3",
+        "@angular/platform-browser": "^19.2.3",
+        "@angular/platform-browser-dynamic": "^19.2.3",
         "@types/jasmine": "^5.1.7",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.13.10",
-        "angular-eslint": "19.2.1",
+        "angular-eslint": "19.3.0",
         "core-js": "^3.41.0",
         "eslint": "^9.22.0",
         "husky": "^9.1.7",
@@ -42,7 +42,7 @@
         "zone.js": "^0.15.0"
       },
       "peerDependencies": {
-        "@angular/core": "^19.2.2"
+        "@angular/core": "^19.2.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -58,13 +58,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1902.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.3.tgz",
-      "integrity": "sha512-6H8MtmskvQyU8kV5Evd8TZHCzdOlFZM9eBVNCld3vuQksE4l98aa6AiSF2u+PJA8Z0+MYYToJJvwmGkLn6XkRQ==",
+      "version": "0.1902.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.4.tgz",
+      "integrity": "sha512-YTLiJ7uVItZTAxRuSgASP0M5qILESWH8xGmfR+YWR1JiJem09DWEOpWeLdha1BFzUui5L+6j1btzh4FUHJOtAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.3",
+        "@angular-devkit/core": "19.2.4",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.3.tgz",
-      "integrity": "sha512-53trlqWu9/grXImOPascS0HcJhzRQfQeeMCTbEKQkxEkKTQPm1/lFQMEQZALigmync8GrkQhFlJ05I4Zhrjk3A==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.4.tgz",
+      "integrity": "sha512-dL6AmCQsKh+CFVvO/jxX8qZpamVwt9r4iIo7fYcAI2+mTSDGxxBGWbS+onIfdPFuRp2HgKa+AT6WiHmRqu63AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -146,17 +146,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.3.tgz",
-      "integrity": "sha512-KUEkuBCENz7NeI7ySFEMLq4jDkFfSzaNNhcBjr3+jcMoGCwayneIh5V6W+I2ynyob5Ejz0D1beCJK5oEnWWDhA==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.4.tgz",
+      "integrity": "sha512-OO8jlLY1SKUbcx3xx4LhbHcecAE9CnMrvIGMOgeKflDI7W57kYUI1lg86k/+Xm76/H2XlbsHdwLKOfFAupfl7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1902.3",
-        "@angular-devkit/build-webpack": "0.1902.3",
-        "@angular-devkit/core": "19.2.3",
-        "@angular/build": "19.2.3",
+        "@angular-devkit/architect": "0.1902.4",
+        "@angular-devkit/build-webpack": "0.1902.4",
+        "@angular-devkit/core": "19.2.4",
+        "@angular/build": "19.2.4",
         "@babel/core": "7.26.10",
         "@babel/generator": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
@@ -167,7 +167,7 @@
         "@babel/preset-env": "7.26.9",
         "@babel/runtime": "7.26.10",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "19.2.3",
+        "@ngtools/webpack": "19.2.4",
         "@vitejs/plugin-basic-ssl": "1.2.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -221,7 +221,7 @@
         "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
         "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
         "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
-        "@angular/ssr": "^19.2.3",
+        "@angular/ssr": "^19.2.4",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.3.tgz",
-      "integrity": "sha512-53trlqWu9/grXImOPascS0HcJhzRQfQeeMCTbEKQkxEkKTQPm1/lFQMEQZALigmync8GrkQhFlJ05I4Zhrjk3A==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.4.tgz",
+      "integrity": "sha512-dL6AmCQsKh+CFVvO/jxX8qZpamVwt9r4iIo7fYcAI2+mTSDGxxBGWbS+onIfdPFuRp2HgKa+AT6WiHmRqu63AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -888,13 +888,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1902.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1902.3.tgz",
-      "integrity": "sha512-s+I3KGGMXb7x+DchThuxZoFwnFcOkLGKa//EpVrrYeZNkp5wwBhrCOojNVNQQeKR7LoYIDM+EvSoLGl+31auAA==",
+      "version": "0.1902.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1902.4.tgz",
+      "integrity": "sha512-TWZsnPMR2JvrQapO7kg4YbUgrKxu74TCYOZZrGfIA7CCIthykflWevMPGZmrTAh3mXX414P31XmoBQViXUe7iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1902.3",
+        "@angular-devkit/architect": "0.1902.4",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -918,13 +918,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.3.tgz",
-      "integrity": "sha512-sYtnOjmhXlR720JdcWXNIP/7aTzfl40uahHxRz2wK3ATK1ifeVaTI9mAJpjFM4KVaguYNis+Mm+rjL7pjbf7Og==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.4.tgz",
+      "integrity": "sha512-WaFe95ncm1A+QTlUHxQcFyGKIn67xgqGX7WCj8R0QlKOS0hLKx97SG4p19uwHlww0lmAcwk/QJP6G6sPL/CJ9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.3",
+        "@angular-devkit/core": "19.2.4",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.3.tgz",
-      "integrity": "sha512-53trlqWu9/grXImOPascS0HcJhzRQfQeeMCTbEKQkxEkKTQPm1/lFQMEQZALigmync8GrkQhFlJ05I4Zhrjk3A==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.4.tgz",
+      "integrity": "sha512-dL6AmCQsKh+CFVvO/jxX8qZpamVwt9r4iIo7fYcAI2+mTSDGxxBGWbS+onIfdPFuRp2HgKa+AT6WiHmRqu63AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1009,9 +1009,9 @@
       }
     },
     "node_modules/@angular-eslint/builder": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-19.2.1.tgz",
-      "integrity": "sha512-iBs/4ZpjyISBFYU+dbfJOJi4Efh7U1hXPgQwaebU9r9Y4dMdcTw7MsaG9MfJX1gQJkIeXasYTxfSfuqoMFl9nQ==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-19.3.0.tgz",
+      "integrity": "sha512-j9xNrzZJq29ONSG6EaeQHve0Squkm6u6Dm8fZgWP7crTFOrtLXn7Wxgxuyl9eddpbWY1Ov1gjFuwBVnxIdyAqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1024,9 +1024,9 @@
       }
     },
     "node_modules/@angular-eslint/builder/node_modules/@angular-devkit/core": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.1.tgz",
-      "integrity": "sha512-DYsoU8emxmBkfIKI693BNUqocwHTVHLjgybyD5nU1qMOH+D/jqEzL5bQbjhUeqeARyrzDg7tyPM5Xno+GsS7KQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.4.tgz",
+      "integrity": "sha512-dL6AmCQsKh+CFVvO/jxX8qZpamVwt9r4iIo7fYcAI2+mTSDGxxBGWbS+onIfdPFuRp2HgKa+AT6WiHmRqu63AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1096,21 +1096,21 @@
       }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-19.2.1.tgz",
-      "integrity": "sha512-8/NY4OCpiRDSOaqnpIOW7kMirqqsTY1U751iuMH0z9gQImYZWubMLOI0tsLFWmz06pKpgiDZcjD2X9TK2b4Igg==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-19.3.0.tgz",
+      "integrity": "sha512-63Zci4pvnUR1iSkikFlNbShF1tO5HOarYd8fvNfmOZwFfZ/1T3j3bCy9YbE+aM5SYrWqPaPP/OcwZ3wJ8WNvqA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.2.1.tgz",
-      "integrity": "sha512-wCjyH5cJb4fBchEnt3L6dQ6syaLHD+xeHCSynD/Lw3K6BcVEnFa+82SfSscgXtYLRPHlkK5CmYYs3AlALhA+/w==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.3.0.tgz",
+      "integrity": "sha512-nBLslLI20KnVbqlfNW7GcnI9R6cYCvRGjOE2QYhzxM316ciAQ62tvQuXP9ZVnRBLSKDAVnMeC0eTq9O4ysrxrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.2.1",
-        "@angular-eslint/utils": "19.2.1"
+        "@angular-eslint/bundled-angular-compiler": "19.3.0",
+        "@angular-eslint/utils": "19.3.0"
       },
       "peerDependencies": {
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
@@ -1119,14 +1119,14 @@
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.2.1.tgz",
-      "integrity": "sha512-yBGut4PedTkZcGbm1sthQ671CXERkC72eXTaZlMRhKNQDf3R6zEVc60q5DQZoEIzvgeIbaZdWhZgsCLwlhfGrQ==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.3.0.tgz",
+      "integrity": "sha512-WyouppTpOYut+wvv13wlqqZ8EHoDrCZxNfGKuEUYK1BPmQlTB8EIZfQH4iR1rFVS28Rw+XRIiXo1x3oC0SOfnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.2.1",
-        "@angular-eslint/utils": "19.2.1",
+        "@angular-eslint/bundled-angular-compiler": "19.3.0",
+        "@angular-eslint/utils": "19.3.0",
         "aria-query": "5.3.2",
         "axobject-query": "4.1.0"
       },
@@ -1138,25 +1138,25 @@
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-19.2.1.tgz",
-      "integrity": "sha512-rfIHIIiXfsShwNbrVoUVu2ZzHkXghuJj8L9pXkdy92DoYSof0lqGURoPb7hv4wvZXGB3yo6S17cbw3IkeYJkzA==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-19.3.0.tgz",
+      "integrity": "sha512-Wl5sFQ4t84LUb8mJ2iVfhYFhtF55IugXu7rRhPHtgIu9Ty5s1v3HGUx4LKv51m2kWhPPeFOTmjeBv1APzFlmnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": ">= 19.0.0 < 20.0.0",
         "@angular-devkit/schematics": ">= 19.0.0 < 20.0.0",
-        "@angular-eslint/eslint-plugin": "19.2.1",
-        "@angular-eslint/eslint-plugin-template": "19.2.1",
+        "@angular-eslint/eslint-plugin": "19.3.0",
+        "@angular-eslint/eslint-plugin-template": "19.3.0",
         "ignore": "7.0.3",
         "semver": "7.7.1",
         "strip-json-comments": "3.1.1"
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.1.tgz",
-      "integrity": "sha512-DYsoU8emxmBkfIKI693BNUqocwHTVHLjgybyD5nU1qMOH+D/jqEzL5bQbjhUeqeARyrzDg7tyPM5Xno+GsS7KQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.4.tgz",
+      "integrity": "sha512-dL6AmCQsKh+CFVvO/jxX8qZpamVwt9r4iIo7fYcAI2+mTSDGxxBGWbS+onIfdPFuRp2HgKa+AT6WiHmRqu63AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1236,13 +1236,13 @@
       }
     },
     "node_modules/@angular-eslint/template-parser": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-19.2.1.tgz",
-      "integrity": "sha512-fU16NUh8nY02zdkHRsAlGI9ruppsE1ko1Z1PIyB3oofYt4rCKsXb8yXWbXWn7qCjNPVqv4+oLx0BwhJQZwEX8w==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-19.3.0.tgz",
+      "integrity": "sha512-VxMNgsHXMWbbmZeBuBX5i8pzsSSEaoACVpaE+j8Muk60Am4Mxc0PytJm4n3znBSvI3B7Kq2+vStSRYPkOER4lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.2.1",
+        "@angular-eslint/bundled-angular-compiler": "19.3.0",
         "eslint-scope": "^8.0.2"
       },
       "peerDependencies": {
@@ -1251,13 +1251,13 @@
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-19.2.1.tgz",
-      "integrity": "sha512-TRIOtlDMbz1PqurLXPKMzSUl2iSs02c185g4EeOzTDX93sDvvVDLRj18jZ0IVcjQv5Vs21JK2KsKV/WdGe1OxA==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-19.3.0.tgz",
+      "integrity": "sha512-ovvbQh96FIJfepHqLCMdKFkPXr3EbcvYc9kMj9hZyIxs/9/VxwPH7x25mMs4VsL6rXVgH2FgG5kR38UZlcTNNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.2.1"
+        "@angular-eslint/bundled-angular-compiler": "19.3.0"
       },
       "peerDependencies": {
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
@@ -1266,14 +1266,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.2.3.tgz",
-      "integrity": "sha512-DJArqWNQrLAx7lVl7qinUROZ5GglgMIpl9Fxchw4fyInjM5TMl0OIkDnZy3wVamlV2JTCk6J38RmlqamcDcJig==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.2.4.tgz",
+      "integrity": "sha512-poCXvmwKri3snWa9zVJ2sW7wyJatZjkwnH6GUBdJrM2dXRQ+LYLk/oXqEjlSRBYNna7P1ZcKNqBbzu0/SnnngA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1902.3",
+        "@angular-devkit/architect": "0.1902.4",
         "@babel/core": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -1313,7 +1313,7 @@
         "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
         "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
         "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
-        "@angular/ssr": "^19.2.3",
+        "@angular/ssr": "^19.2.4",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^19.0.0 || ^19.2.0-next.0",
@@ -1938,18 +1938,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.3.tgz",
-      "integrity": "sha512-p6w/ZsVjF9htE0BnFraKVCtd/Fx5UolVuGyTl4VOKBsml0ebDgzkfaiMRqI06F1BMOnwOszEZvTcduXA/Fwf+Q==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.4.tgz",
+      "integrity": "sha512-YmZYrxdGBwSZsrnpS6vr9gQ8+PrZHzwyYW/3jU2NRAMtl0ZlipDyfpLIDgrfqYPeumzr7+SKtJYVvlsMnjkN4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1902.3",
-        "@angular-devkit/core": "19.2.3",
-        "@angular-devkit/schematics": "19.2.3",
+        "@angular-devkit/architect": "0.1902.4",
+        "@angular-devkit/core": "19.2.4",
+        "@angular-devkit/schematics": "19.2.4",
         "@inquirer/prompts": "7.3.2",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.2.3",
+        "@schematics/angular": "19.2.4",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -1972,9 +1972,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.3.tgz",
-      "integrity": "sha512-53trlqWu9/grXImOPascS0HcJhzRQfQeeMCTbEKQkxEkKTQPm1/lFQMEQZALigmync8GrkQhFlJ05I4Zhrjk3A==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.4.tgz",
+      "integrity": "sha512-dL6AmCQsKh+CFVvO/jxX8qZpamVwt9r4iIo7fYcAI2+mTSDGxxBGWbS+onIfdPFuRp2HgKa+AT6WiHmRqu63AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2044,9 +2044,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.2.tgz",
-      "integrity": "sha512-tLb4/gAjy1WFYZd68FnwLaC8w3b10RG8r+x5MUnbyhJa9K3qILzF8gWUVJ4tKLKentB3fWPWPNs9OFZH5XVf1g==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.3.tgz",
+      "integrity": "sha512-cYOMRXFb6Sjtg9BI3bE/Ave+xU234jQmHYj7hBxr3MiqRSVJL4niy10KiA/Jiz6y76V5QfZfS+0aE65VuoqAvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2056,14 +2056,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.2.2",
+        "@angular/core": "19.2.3",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.2.tgz",
-      "integrity": "sha512-Aa5BTaSC6QInjiyTrjfTElKYC07trozdWuPhdG6JiwSAZ/ryQDzMLayHQ+MJSq3TsvpwNd+ld86RK0ARRSmJbA==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.3.tgz",
+      "integrity": "sha512-TL/JIU7vzSWD+IrMq2PAiHZi7IUFSRhdHo8q6/WuZ8SQmbuXCK2pJvHZpTtUdLswdPeD/UVhkhTAhQzEyEdZVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2071,20 +2071,12 @@
       },
       "engines": {
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "19.2.2"
-      },
-      "peerDependenciesMeta": {
-        "@angular/core": {
-          "optional": true
-        }
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.2.tgz",
-      "integrity": "sha512-RPUSZGf1wnSyDkwt3pZ0W/m3e3+vM1PwdgLpV5OGGJSki0VtNFp2xlnCpwrF/EDPJk2kLBj7nQADfB/P5lX9eA==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.3.tgz",
+      "integrity": "sha512-ePh/7A6eEDAyfVn8QgLcAvrxhXBAf6mTqB/3+HwQeXLaka1gtN6xvZ6cjLEegP4s6kcYGhdfdLwzCcy0kjsY5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2106,7 +2098,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.2.2",
+        "@angular/compiler": "19.2.3",
         "typescript": ">=5.5 <5.9"
       }
     },
@@ -2137,9 +2129,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.2.tgz",
-      "integrity": "sha512-RL2wxk62BREW4sksnBSjtBDgPxHqIJQKkrlxXbbu2jZql7xohEQtdTZP3DB6iWnZLYgz8CAfTzyaHMvj6HfdLg==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.3.tgz",
+      "integrity": "sha512-uNDbQBDWdAfL8JhgG2l9eTEbikovZ+SthLUKERyR4fL7AVGSx85LjNySRuq4WAL4eiD1cRN1UUgu8o+WKqF/ow==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2154,9 +2146,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.2.tgz",
-      "integrity": "sha512-D15zwFiOczbPhJrdCgbuZwSDwQb6uyDjM5YI3SgIFIxP2JiVdBg3AvmqoJQOuU8ntMeeiOxtdl8nqcvUddhdPw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.3.tgz",
+      "integrity": "sha512-bz5mvUkCS8SxaMInjPgi/2dD7vpWkZePQesvr/bBRNQbYSE4cGTbovXcVl3X5hIxs5JoC6Het0lS2IxDq7j6qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2166,9 +2158,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.2.2",
-        "@angular/common": "19.2.2",
-        "@angular/core": "19.2.2"
+        "@angular/animations": "19.2.3",
+        "@angular/common": "19.2.3",
+        "@angular/core": "19.2.3"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -2177,9 +2169,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.2.tgz",
-      "integrity": "sha512-N3Zb9qMZ3+ygDBr8uaMmUwmKFaVExF0RNzLMMsQy1qSDBbdKybBqN9dnBgtdJWUN/ORGVHhmOfosaWgLOyyU4A==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.3.tgz",
+      "integrity": "sha512-PHmmtdGxSfe9HL8xR4g3PspnEaPqTEOGyzNviAHugfkZCgXCdSbYs36d3i0nPwhExMAeuIVXbbJyouDn2kyeOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2189,10 +2181,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.2.2",
-        "@angular/compiler": "19.2.2",
-        "@angular/core": "19.2.2",
-        "@angular/platform-browser": "19.2.2"
+        "@angular/common": "19.2.3",
+        "@angular/compiler": "19.2.3",
+        "@angular/core": "19.2.3",
+        "@angular/platform-browser": "19.2.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5279,9 +5271,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.3.tgz",
-      "integrity": "sha512-jN9wxtrLKX1myOXYMRiOs3jCgdruvYW13zHQWTmh1oyKiYNA0wO328R9nHUTRcYaXzj2nhUZvksafqHf254GWQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.4.tgz",
+      "integrity": "sha512-I2vG9Yb0W/PR5+quBmSUk6uGa4xN/YvfJk+30bFDB/CpJlTQEo+3AOFCDYcDOxrbtjON80VdFYPypQ5ztbpdYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5988,14 +5980,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.3.tgz",
-      "integrity": "sha512-bhtGJtetkiqyB/OR506ftC+o98xLQXnOlvFO/zbkTddkLgMdPpyOt2A9Fuu+z4OVigqBiLBkzmR8i0w8xUUAmw==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.4.tgz",
+      "integrity": "sha512-P7fphIPbqHHYRVRPiFl7RAHYPYhINGSUYOXrcThVBBsgKQBX18oNdUWvhZA6ylwK/9T21XB20VyLjNy0d78H1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.3",
-        "@angular-devkit/schematics": "19.2.3",
+        "@angular-devkit/core": "19.2.4",
+        "@angular-devkit/schematics": "19.2.4",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -6005,9 +5997,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.3.tgz",
-      "integrity": "sha512-53trlqWu9/grXImOPascS0HcJhzRQfQeeMCTbEKQkxEkKTQPm1/lFQMEQZALigmync8GrkQhFlJ05I4Zhrjk3A==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.4.tgz",
+      "integrity": "sha512-dL6AmCQsKh+CFVvO/jxX8qZpamVwt9r4iIo7fYcAI2+mTSDGxxBGWbS+onIfdPFuRp2HgKa+AT6WiHmRqu63AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7092,19 +7084,19 @@
       }
     },
     "node_modules/angular-eslint": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-19.2.1.tgz",
-      "integrity": "sha512-YQMHvbxn7G+vQ97KGr1vVSAvEFKCegcm2QcehN1eZqnTFvR4eaZyZUbIc/EaF0p9W8Jds2iKrtsVTi8zzDB+LA==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-19.3.0.tgz",
+      "integrity": "sha512-19hkkH3z/2wGhKk3LfttEBkl6CtQP/tFK6/mJoO/MbIkXV0SSJWtbPbOpEaxICLlfCw0oR6W9OoQqByWkwXjkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": ">= 19.0.0 < 20.0.0",
         "@angular-devkit/schematics": ">= 19.0.0 < 20.0.0",
-        "@angular-eslint/builder": "19.2.1",
-        "@angular-eslint/eslint-plugin": "19.2.1",
-        "@angular-eslint/eslint-plugin-template": "19.2.1",
-        "@angular-eslint/schematics": "19.2.1",
-        "@angular-eslint/template-parser": "19.2.1",
+        "@angular-eslint/builder": "19.3.0",
+        "@angular-eslint/eslint-plugin": "19.3.0",
+        "@angular-eslint/eslint-plugin-template": "19.3.0",
+        "@angular-eslint/schematics": "19.3.0",
+        "@angular-eslint/template-parser": "19.3.0",
         "@typescript-eslint/types": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -27,20 +27,20 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^19.2.2"
+    "@angular/core": "^19.2.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^19.2.3",
-    "@angular/cli": "^19.2.3",
-    "@angular/common": "^19.2.2",
-    "@angular/compiler": "^19.2.2",
-    "@angular/compiler-cli": "^19.2.2",
-    "@angular/platform-browser": "^19.2.2",
-    "@angular/platform-browser-dynamic": "^19.2.2",
+    "@angular-devkit/build-angular": "^19.2.4",
+    "@angular/cli": "^19.2.4",
+    "@angular/common": "^19.2.3",
+    "@angular/compiler": "^19.2.3",
+    "@angular/compiler-cli": "^19.2.3",
+    "@angular/platform-browser": "^19.2.3",
+    "@angular/platform-browser-dynamic": "^19.2.3",
     "@types/jasmine": "^5.1.7",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.13.10",
-    "angular-eslint": "19.2.1",
+    "angular-eslint": "19.3.0",
     "core-js": "^3.41.0",
     "eslint": "^9.22.0",
     "husky": "^9.1.7",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 32 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       19.2.3 -> 19.2.4         ng update @angular/cli
      @angular/core                      19.2.2 -> 19.2.3         ng update @angular/core
      angular-eslint                     19.2.1 -> 19.3.0         ng update angular-eslint
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>