### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^19.2.8",
-        "@angular/cli": "^19.2.8",
-        "@angular/common": "^19.2.7",
-        "@angular/compiler": "^19.2.7",
-        "@angular/compiler-cli": "^19.2.7",
-        "@angular/platform-browser": "^19.2.7",
-        "@angular/platform-browser-dynamic": "^19.2.7",
+        "@angular-devkit/build-angular": "^19.2.9",
+        "@angular/cli": "^19.2.9",
+        "@angular/common": "^19.2.8",
+        "@angular/compiler": "^19.2.8",
+        "@angular/compiler-cli": "^19.2.8",
+        "@angular/platform-browser": "^19.2.8",
+        "@angular/platform-browser-dynamic": "^19.2.8",
         "@types/jasmine": "^5.1.7",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.15.2",
@@ -42,7 +42,7 @@
         "zone.js": "^0.15.0"
       },
       "peerDependencies": {
-        "@angular/core": "^19.2.7"
+        "@angular/core": "^19.2.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -58,13 +58,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1902.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.8.tgz",
-      "integrity": "sha512-0A1EhtC/A/N7ukOD+s04l7sCyeSF5llBupkZdksSfi5y56s8U6Lt7KuqrbsErkOKgaCWrP/+Ef8fo0RmYpnefQ==",
+      "version": "0.1902.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.9.tgz",
+      "integrity": "sha512-SLUc7EaFMjhCnimqxTcv32wESJBLQ3E6c/1sAndPojyCoGiX24ASu2pxrTXrYNS9DqiJT8tReAnqmh7dmf3xwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.8",
+        "@angular-devkit/core": "19.2.9",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.8.tgz",
-      "integrity": "sha512-kcxUHKf5Hi98r4gAvMP3ntJV8wuQ3/i6wuU9RcMP0UKUt2Rer5Ryis3MPqT92jvVVwg6lhrLIhXsFuWJMiYjXQ==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
+      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -146,17 +146,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.8.tgz",
-      "integrity": "sha512-jlOig9cXfjvH34mq74wAznXpRTb88XP1g5ZE8rKch4qGwh+mFF7aES86MxCvMZGXgz6KckC5dIEL7VHuB7NVCA==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.9.tgz",
+      "integrity": "sha512-v6x3h+LYyEew3EjoI1+2IiFDz6f96lJB1JvbbZj3Li9FMhO4M/xo4BaWHbeg9Lot/vUy6IAlR+BJywawNIzv0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1902.8",
-        "@angular-devkit/build-webpack": "0.1902.8",
-        "@angular-devkit/core": "19.2.8",
-        "@angular/build": "19.2.8",
+        "@angular-devkit/architect": "0.1902.9",
+        "@angular-devkit/build-webpack": "0.1902.9",
+        "@angular-devkit/core": "19.2.9",
+        "@angular/build": "19.2.9",
         "@babel/core": "7.26.10",
         "@babel/generator": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
@@ -167,7 +167,7 @@
         "@babel/preset-env": "7.26.9",
         "@babel/runtime": "7.26.10",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "19.2.8",
+        "@ngtools/webpack": "19.2.9",
         "@vitejs/plugin-basic-ssl": "1.2.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -177,7 +177,7 @@
         "css-loader": "7.1.2",
         "esbuild-wasm": "0.25.1",
         "fast-glob": "3.3.3",
-        "http-proxy-middleware": "3.0.3",
+        "http-proxy-middleware": "3.0.5",
         "istanbul-lib-instrument": "6.0.3",
         "jsonc-parser": "3.3.1",
         "karma-source-map-support": "1.4.0",
@@ -221,7 +221,7 @@
         "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
         "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
         "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
-        "@angular/ssr": "^19.2.8",
+        "@angular/ssr": "^19.2.9",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.8.tgz",
-      "integrity": "sha512-kcxUHKf5Hi98r4gAvMP3ntJV8wuQ3/i6wuU9RcMP0UKUt2Rer5Ryis3MPqT92jvVVwg6lhrLIhXsFuWJMiYjXQ==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
+      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -888,13 +888,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1902.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1902.8.tgz",
-      "integrity": "sha512-0X7Lou22VV5ZoG9AW9q1+0kqWbaq51vHZg0YnjfqxEZ1gqKXqE4flZHAvUhm92aeRp8O1UH8YqujwqiCGzvCNg==",
+      "version": "0.1902.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1902.9.tgz",
+      "integrity": "sha512-iklNoxKgwd54KT5GE0o5SB+0hr6Iu3YSpj9fi23DlLKcWWwFYaKqoRaYcfuL7KdUzunFg7dzB7n6TgYpVHWWJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1902.8",
+        "@angular-devkit/architect": "0.1902.9",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -918,13 +918,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.8.tgz",
-      "integrity": "sha512-QsmFuYdAyeCyg9WF/AJBhFXDUfCwmDFTEbsv5t5KPSP6slhk0GoLNZApniiFytU2siRlSxVNpve2uATyYuAYkQ==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.9.tgz",
+      "integrity": "sha512-B8FQ4hFsP4Ffh895F9GVvyhgDoZztWnAyYKiM1pyvLSQikzaUZqi9NZnD12HgMALmwm2z36zTzoSNsYFBTHgaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.8",
+        "@angular-devkit/core": "19.2.9",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.8.tgz",
-      "integrity": "sha512-kcxUHKf5Hi98r4gAvMP3ntJV8wuQ3/i6wuU9RcMP0UKUt2Rer5Ryis3MPqT92jvVVwg6lhrLIhXsFuWJMiYjXQ==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
+      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1266,14 +1266,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.2.8.tgz",
-      "integrity": "sha512-lfg9OZqRZhmaXbmZTjSE24auOskd7XSbWjZsYodGcW4dYfZdCGkI1g2bP/p6EGQqm+8Vw+IHecyzHLtdJNcbpA==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.2.9.tgz",
+      "integrity": "sha512-hrRhSdY98wGQ/jrpT3K73/Ii5FadQEJFcHy+ockqP2Xh7pXOwhGFc+D0ks4AdHea+pHtNbIb/qPd+UvR5izY3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1902.8",
+        "@angular-devkit/architect": "0.1902.9",
         "@babel/core": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -1313,7 +1313,7 @@
         "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
         "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
         "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
-        "@angular/ssr": "^19.2.8",
+        "@angular/ssr": "^19.2.9",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^19.0.0 || ^19.2.0-next.0",
@@ -1938,18 +1938,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.8.tgz",
-      "integrity": "sha512-8/6HBgmqjE8fODFeIIohHVbmCjYlYQj3anvZneEUAGlRbr2IvLUxj7k1/O+9pawEEsOsyjXh5bIvFmEzL19fBw==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.9.tgz",
+      "integrity": "sha512-m3yaqrtodzO+tDspAqD6h7Ft8HzP4xbTmqPoSHaAN6Wupf/m/q94AMBmuEk74URS3q7v6PhayOuNOzBY2q4bIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1902.8",
-        "@angular-devkit/core": "19.2.8",
-        "@angular-devkit/schematics": "19.2.8",
+        "@angular-devkit/architect": "0.1902.9",
+        "@angular-devkit/core": "19.2.9",
+        "@angular-devkit/schematics": "19.2.9",
         "@inquirer/prompts": "7.3.2",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.2.8",
+        "@schematics/angular": "19.2.9",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -1972,9 +1972,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.8.tgz",
-      "integrity": "sha512-kcxUHKf5Hi98r4gAvMP3ntJV8wuQ3/i6wuU9RcMP0UKUt2Rer5Ryis3MPqT92jvVVwg6lhrLIhXsFuWJMiYjXQ==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
+      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2044,9 +2044,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.7.tgz",
-      "integrity": "sha512-It6G8ohe0R5J6+YoCB6eDgmMp55+zYlbCIqEq1AoRPVTO7oVn5X65SIRDBlgpx4kzoBLeeYjDt8WUk4qIZ0GLQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.8.tgz",
+      "integrity": "sha512-SnW+/amz1Mtni9125xlzPZ5MU+wSzUepc9G5jRnL0q9vrFglRWa3BEW3GxVurfbdnf6FleroZ7fZCZFAfREw7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2056,14 +2056,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.2.7",
+        "@angular/core": "19.2.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.7.tgz",
-      "integrity": "sha512-YHXqDX7VVhfZpRa+ljJZW+PONKjg/LGwdGBBGk3955Ww4Ql+Gjrnv0OxFhChUdwCgsl3yTSXfVep29jYCp6dbA==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.8.tgz",
+      "integrity": "sha512-HBtt96X09XFatHAnkquFYbcD3aQSvuYoqqhCV5OLkhAwHmvr3BGyHx/EBZ5JGOfCNOzCupoQmOBF+nh5LKwkeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2074,9 +2074,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.7.tgz",
-      "integrity": "sha512-NMRCqzmDyPx4nZDgdyDtjZqpFJ+Yc0GoDVRwEILXnKA26yHkptoGQHLcasZAOxjCA0uqLuLqNVRG/IwkCoTb2Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.8.tgz",
+      "integrity": "sha512-gq/sc3D3m6aKmhdSTTzzD59wfQcVjIZ8dgJoPW7pOcmPVQL1N8syjv+quHySfSJlBkbs5dQ0P4Kk0yvxRw9S7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2098,7 +2098,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.2.7",
+        "@angular/compiler": "19.2.8",
         "typescript": ">=5.5 <5.9"
       }
     },
@@ -2129,9 +2129,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.7.tgz",
-      "integrity": "sha512-Ft3cTkXNU538wLDNI4qesFLVfDLXCSHq0uSmi53bHJJxddEJmjD73mGkYA4GGPc3NghQiDEcHuNoTZ3EXWbxjg==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.8.tgz",
+      "integrity": "sha512-iNISGgLr+nBzEaGbfzRCOVfV3T66gbEu+Ee4VCnEqifU7Er6fnvn+oFfHo3gNKHrCdicrbyb2oKAmeOJynKbsA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2146,9 +2146,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.7.tgz",
-      "integrity": "sha512-3kwatNyOUzdt3p92f6SRrNEnYbRVTBl7jL3t2wB+6RDWGboJXGjzFjGqpPpdIftTG56uUijPqZXmQ0gpSgtvuQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.8.tgz",
+      "integrity": "sha512-3O69vMAq/ki13YX8hWBUs1R6iwS1GmkcHWu5fIUU7rjSuhGfD60nASqRBYZiJb68eUom//T544KavOvfAl1PzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2158,9 +2158,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.2.7",
-        "@angular/common": "19.2.7",
-        "@angular/core": "19.2.7"
+        "@angular/animations": "19.2.8",
+        "@angular/common": "19.2.8",
+        "@angular/core": "19.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -2169,9 +2169,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.7.tgz",
-      "integrity": "sha512-x52xcUzx2IK3JElyD73gJ6t7B6Y8F/Imgs9Ob0B+zYpow3RGva5501m0fHUm8UbOXAD0t11kX68MW4fUp+TRTg==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.8.tgz",
+      "integrity": "sha512-Vwh53CGCC/I3DQ/nqWxNTKk052CRHv46H6KjfWBsD8vOVTJoQf2HXwEbDKntpmJ0K4MtMdIdbpwXieUMLyfmXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2181,10 +2181,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.2.7",
-        "@angular/compiler": "19.2.7",
-        "@angular/core": "19.2.7",
-        "@angular/platform-browser": "19.2.7"
+        "@angular/common": "19.2.8",
+        "@angular/compiler": "19.2.8",
+        "@angular/core": "19.2.8",
+        "@angular/platform-browser": "19.2.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5271,9 +5271,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.8.tgz",
-      "integrity": "sha512-PBuEadA1bM3BYqo49FdXIgehgEGMSnPmbfmeMC5xRtOXNw8Ear2ogjqPoOj45L98grcS2XyJPlctC7C8kQpA+g==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.9.tgz",
+      "integrity": "sha512-CLfUauqi2Xp/jKGxp5wUwjqfVQWcBE09GMd51ovcCRLkgB2Kh26+CiVnGw5/lkBpISUCNdgN6nGiS+nfqMfFeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5995,14 +5995,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.8.tgz",
-      "integrity": "sha512-oE/RzC9a0kS6+T72zX08Qkh42tbHlPZxFx1lm3saIzU9mifxlQRT9Od4PK+yksDBvxvtr+TcM2KVOqxCujpHXg==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.9.tgz",
+      "integrity": "sha512-V5c8qycipodwbDX3lY0sbQaG2OKkO2HdjxL0K70TzcpEwnD4uVMs73PRaLtREASzpnSo6CKewQCsgPSgyzJCKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.8",
-        "@angular-devkit/schematics": "19.2.8",
+        "@angular-devkit/core": "19.2.9",
+        "@angular-devkit/schematics": "19.2.9",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -6012,9 +6012,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.8.tgz",
-      "integrity": "sha512-kcxUHKf5Hi98r4gAvMP3ntJV8wuQ3/i6wuU9RcMP0UKUt2Rer5Ryis3MPqT92jvVVwg6lhrLIhXsFuWJMiYjXQ==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
+      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6429,7 +6429,9 @@
       "license": "MIT"
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.15",
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9111,9 +9113,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -11172,7 +11174,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.3",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11189,6 +11193,8 @@
     },
     "node_modules/http-proxy-middleware/node_modules/is-plain-object": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14755,13 +14761,13 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
-      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.5.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -14793,6 +14799,19 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -17766,19 +17785,19 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
-      "integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
+      "integrity": "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.3",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
         "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.12"
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^19.2.7"
+    "@angular/core": "^19.2.8"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^19.2.8",
-    "@angular/cli": "^19.2.8",
-    "@angular/common": "^19.2.7",
-    "@angular/compiler": "^19.2.7",
-    "@angular/compiler-cli": "^19.2.7",
-    "@angular/platform-browser": "^19.2.7",
-    "@angular/platform-browser-dynamic": "^19.2.7",
+    "@angular-devkit/build-angular": "^19.2.9",
+    "@angular/cli": "^19.2.9",
+    "@angular/common": "^19.2.8",
+    "@angular/compiler": "^19.2.8",
+    "@angular/compiler-cli": "^19.2.8",
+    "@angular/platform-browser": "^19.2.8",
+    "@angular/platform-browser-dynamic": "^19.2.8",
     "@types/jasmine": "^5.1.7",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.15.2",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 32 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       19.2.8 -> 19.2.9         ng update @angular/cli
      @angular/core                      19.2.7 -> 19.2.8         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>