### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^19.2.9",
-        "@angular/cli": "^19.2.9",
-        "@angular/common": "^19.2.8",
-        "@angular/compiler": "^19.2.8",
-        "@angular/compiler-cli": "^19.2.8",
-        "@angular/platform-browser": "^19.2.8",
-        "@angular/platform-browser-dynamic": "^19.2.8",
+        "@angular-devkit/build-angular": "^19.2.10",
+        "@angular/cli": "^19.2.10",
+        "@angular/common": "^19.2.9",
+        "@angular/compiler": "^19.2.9",
+        "@angular/compiler-cli": "^19.2.9",
+        "@angular/platform-browser": "^19.2.9",
+        "@angular/platform-browser-dynamic": "^19.2.9",
         "@types/jasmine": "^5.1.7",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.15.3",
@@ -42,7 +42,7 @@
         "zone.js": "^0.15.0"
       },
       "peerDependencies": {
-        "@angular/core": "^19.2.8"
+        "@angular/core": "^19.2.9"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -58,13 +58,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1902.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.9.tgz",
-      "integrity": "sha512-SLUc7EaFMjhCnimqxTcv32wESJBLQ3E6c/1sAndPojyCoGiX24ASu2pxrTXrYNS9DqiJT8tReAnqmh7dmf3xwQ==",
+      "version": "0.1902.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.10.tgz",
+      "integrity": "sha512-Oa0mJi/SgBFLpZTzyO1KfkrS8dKvFnOl8pxJNb51s5i+yUSBNQOC7H6ulq4sSPjswzPe2vcizoKIxBkdLjwJDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.9",
+        "@angular-devkit/core": "19.2.10",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
-      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.10.tgz",
+      "integrity": "sha512-xYF+Vgc+j6iPboR0uptQk3QFed5n/0KSgITbfV/uPEqhzSNdkiM4Y2i/sKlTZrI07cRK/m/dbZ6sZsbvXJVtkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -146,17 +146,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.9.tgz",
-      "integrity": "sha512-v6x3h+LYyEew3EjoI1+2IiFDz6f96lJB1JvbbZj3Li9FMhO4M/xo4BaWHbeg9Lot/vUy6IAlR+BJywawNIzv0Q==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.10.tgz",
+      "integrity": "sha512-YaGfGxHFvlXLkaYQl++mOPYagT0jm65D4aTp1YxbvCSjrbTG1++sAvaR50VN71ZnbnGpEq807PHIwBp6eWluiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1902.9",
-        "@angular-devkit/build-webpack": "0.1902.9",
-        "@angular-devkit/core": "19.2.9",
-        "@angular/build": "19.2.9",
+        "@angular-devkit/architect": "0.1902.10",
+        "@angular-devkit/build-webpack": "0.1902.10",
+        "@angular-devkit/core": "19.2.10",
+        "@angular/build": "19.2.10",
         "@babel/core": "7.26.10",
         "@babel/generator": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
@@ -167,7 +167,7 @@
         "@babel/preset-env": "7.26.9",
         "@babel/runtime": "7.26.10",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "19.2.9",
+        "@ngtools/webpack": "19.2.10",
         "@vitejs/plugin-basic-ssl": "1.2.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -221,7 +221,7 @@
         "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
         "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
         "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
-        "@angular/ssr": "^19.2.9",
+        "@angular/ssr": "^19.2.10",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
-      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.10.tgz",
+      "integrity": "sha512-xYF+Vgc+j6iPboR0uptQk3QFed5n/0KSgITbfV/uPEqhzSNdkiM4Y2i/sKlTZrI07cRK/m/dbZ6sZsbvXJVtkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -888,13 +888,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1902.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1902.9.tgz",
-      "integrity": "sha512-iklNoxKgwd54KT5GE0o5SB+0hr6Iu3YSpj9fi23DlLKcWWwFYaKqoRaYcfuL7KdUzunFg7dzB7n6TgYpVHWWJw==",
+      "version": "0.1902.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1902.10.tgz",
+      "integrity": "sha512-nf8ce3T+kfaU1cmwawxCsRl4Q6TZzVzFIOCW+NpTeFtqUAhGkLiSO+qvWCAUiLSSpqxjvRpgh2LIV1SxaayfbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1902.9",
+        "@angular-devkit/architect": "0.1902.10",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -918,13 +918,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.9.tgz",
-      "integrity": "sha512-B8FQ4hFsP4Ffh895F9GVvyhgDoZztWnAyYKiM1pyvLSQikzaUZqi9NZnD12HgMALmwm2z36zTzoSNsYFBTHgaw==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.10.tgz",
+      "integrity": "sha512-S+7Mvi9GMiJu3BY0Dpa7TrrAiFIwGwCIKLpO0IgGLUDh9fVLIlcIC/PZgU+L46gEpRwPZfrfMbDFKIlGGz/eQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.9",
+        "@angular-devkit/core": "19.2.10",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
-      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.10.tgz",
+      "integrity": "sha512-xYF+Vgc+j6iPboR0uptQk3QFed5n/0KSgITbfV/uPEqhzSNdkiM4Y2i/sKlTZrI07cRK/m/dbZ6sZsbvXJVtkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1266,14 +1266,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.2.9.tgz",
-      "integrity": "sha512-hrRhSdY98wGQ/jrpT3K73/Ii5FadQEJFcHy+ockqP2Xh7pXOwhGFc+D0ks4AdHea+pHtNbIb/qPd+UvR5izY3Q==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.2.10.tgz",
+      "integrity": "sha512-1+veE1S2fuQ3WjzYBabjk5/+7TM91kkyvKo+2P8vc0eb+c9K2VfYx+6ErCHs38mPPqL1JjixsX9Nqbd5b7yowA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1902.9",
+        "@angular-devkit/architect": "0.1902.10",
         "@babel/core": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -1296,7 +1296,7 @@
         "sass": "1.85.0",
         "semver": "7.7.1",
         "source-map-support": "0.5.21",
-        "vite": "6.2.6",
+        "vite": "6.2.7",
         "watchpack": "2.4.2"
       },
       "engines": {
@@ -1313,7 +1313,7 @@
         "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
         "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
         "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
-        "@angular/ssr": "^19.2.9",
+        "@angular/ssr": "^19.2.10",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^19.0.0 || ^19.2.0-next.0",
@@ -1866,9 +1866,9 @@
       }
     },
     "node_modules/@angular/build/node_modules/vite": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
-      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.7.tgz",
+      "integrity": "sha512-qg3LkeuinTrZoJHHF94coSaTfIPyBYoywp+ys4qu20oSJFbKMYoIJo0FWJT9q6Vp49l6z9IsJRbHdcGtiKbGoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1938,18 +1938,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.9.tgz",
-      "integrity": "sha512-m3yaqrtodzO+tDspAqD6h7Ft8HzP4xbTmqPoSHaAN6Wupf/m/q94AMBmuEk74URS3q7v6PhayOuNOzBY2q4bIw==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.10.tgz",
+      "integrity": "sha512-gKQ63HJghKUoysCxL15GvKD+WkAG9E579PoH53oJLaIAtfCe30t4CC1BYfmhsvmqt/pt7TMb74f+Q+ckrbkS3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1902.9",
-        "@angular-devkit/core": "19.2.9",
-        "@angular-devkit/schematics": "19.2.9",
+        "@angular-devkit/architect": "0.1902.10",
+        "@angular-devkit/core": "19.2.10",
+        "@angular-devkit/schematics": "19.2.10",
         "@inquirer/prompts": "7.3.2",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.2.9",
+        "@schematics/angular": "19.2.10",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -1972,9 +1972,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
-      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.10.tgz",
+      "integrity": "sha512-xYF+Vgc+j6iPboR0uptQk3QFed5n/0KSgITbfV/uPEqhzSNdkiM4Y2i/sKlTZrI07cRK/m/dbZ6sZsbvXJVtkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2044,9 +2044,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.8.tgz",
-      "integrity": "sha512-SnW+/amz1Mtni9125xlzPZ5MU+wSzUepc9G5jRnL0q9vrFglRWa3BEW3GxVurfbdnf6FleroZ7fZCZFAfREw7Q==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.9.tgz",
+      "integrity": "sha512-4Lio3nRp13sTU15hsVcv8Zkj+7OKZ6Pc6CIIkQYHs9KisSwwvwmRZDU1wFhKlH+ogebLgOcNurIPdqeYWWnLjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2056,14 +2056,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.2.8",
+        "@angular/core": "19.2.9",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.8.tgz",
-      "integrity": "sha512-HBtt96X09XFatHAnkquFYbcD3aQSvuYoqqhCV5OLkhAwHmvr3BGyHx/EBZ5JGOfCNOzCupoQmOBF+nh5LKwkeQ==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.9.tgz",
+      "integrity": "sha512-K6wtAsJhQeD2OjoupV03gWHBqnqhEP9llzFzlnQoXAAZzM1eIT/KAtQEdNY75NO+BESKxaXvQBAU16Tg/1I6uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2074,9 +2074,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.8.tgz",
-      "integrity": "sha512-gq/sc3D3m6aKmhdSTTzzD59wfQcVjIZ8dgJoPW7pOcmPVQL1N8syjv+quHySfSJlBkbs5dQ0P4Kk0yvxRw9S7g==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.9.tgz",
+      "integrity": "sha512-+tTxBHO0siPPK6yxQeEQOS/Ihn9ntEa/uiwVO2IEaCrsmRLEYS6Wwqq7H3x7Pj64axnZdA0YRo8kOyTUbMs4+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2098,7 +2098,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.2.8",
+        "@angular/compiler": "19.2.9",
         "typescript": ">=5.5 <5.9"
       }
     },
@@ -2129,9 +2129,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.8.tgz",
-      "integrity": "sha512-iNISGgLr+nBzEaGbfzRCOVfV3T66gbEu+Ee4VCnEqifU7Er6fnvn+oFfHo3gNKHrCdicrbyb2oKAmeOJynKbsA==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.9.tgz",
+      "integrity": "sha512-73WMvxWll8/nQiAbigDhR27dQ+GjciODY5JVADdneNBSEwcQxi0HirlGzm5wy1TonOu4eTTWkvgV/3YlTOmo4A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2146,9 +2146,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.8.tgz",
-      "integrity": "sha512-3O69vMAq/ki13YX8hWBUs1R6iwS1GmkcHWu5fIUU7rjSuhGfD60nASqRBYZiJb68eUom//T544KavOvfAl1PzQ==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.9.tgz",
+      "integrity": "sha512-vMBgCj/R2OxVX7YAqBTOsBiEUbwB3sJoZSy+E05vJovC0QhPWTiR4QiBXB1nlCoAZ8HTv79j7j8AYl10pqlPfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2158,9 +2158,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.2.8",
-        "@angular/common": "19.2.8",
-        "@angular/core": "19.2.8"
+        "@angular/animations": "19.2.9",
+        "@angular/common": "19.2.9",
+        "@angular/core": "19.2.9"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -2169,9 +2169,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.8.tgz",
-      "integrity": "sha512-Vwh53CGCC/I3DQ/nqWxNTKk052CRHv46H6KjfWBsD8vOVTJoQf2HXwEbDKntpmJ0K4MtMdIdbpwXieUMLyfmXA==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.9.tgz",
+      "integrity": "sha512-llyjP1d3f6NDP6GwfHVNKZmkHlKpRKR/nYvP60Xl5vt90Gw2H5MJ+JHlzAHMt4O4paQHaYH1+b+2bio5/VSxjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2181,10 +2181,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.2.8",
-        "@angular/compiler": "19.2.8",
-        "@angular/core": "19.2.8",
-        "@angular/platform-browser": "19.2.8"
+        "@angular/common": "19.2.9",
+        "@angular/compiler": "19.2.9",
+        "@angular/core": "19.2.9",
+        "@angular/platform-browser": "19.2.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5271,9 +5271,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.9.tgz",
-      "integrity": "sha512-CLfUauqi2Xp/jKGxp5wUwjqfVQWcBE09GMd51ovcCRLkgB2Kh26+CiVnGw5/lkBpISUCNdgN6nGiS+nfqMfFeQ==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.10.tgz",
+      "integrity": "sha512-L6X4BbP0zENnOU6++e2sVcMJnsVu2sS3xDeKE2Ybj6gLXdbk4LG1zeYLcrNft5MKEE3mqrygNxlMay7G95cpQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5878,9 +5878,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.0.tgz",
-      "integrity": "sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.1.tgz",
+      "integrity": "sha512-n/vQ4xRZXKuIpqukkMXZt9RWdl+2zgGNx7Uda8NtmLJ06NL8jiHxUawbwC+hdSq1rrw/9CghCpEONor+l1e2gA==",
       "cpu": [
         "riscv64"
       ],
@@ -5995,14 +5995,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.9.tgz",
-      "integrity": "sha512-V5c8qycipodwbDX3lY0sbQaG2OKkO2HdjxL0K70TzcpEwnD4uVMs73PRaLtREASzpnSo6CKewQCsgPSgyzJCKw==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.10.tgz",
+      "integrity": "sha512-ZcsS3FyYdSkV6Br+vtYvn0eQP/H3AAZI4aBg3XVbIxRbWG5rChTqN5J9C8Ncl0VET7OAj+PeQwoFH6jFenVw0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.9",
-        "@angular-devkit/schematics": "19.2.9",
+        "@angular-devkit/core": "19.2.10",
+        "@angular-devkit/schematics": "19.2.10",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -6012,9 +6012,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.9.tgz",
-      "integrity": "sha512-vbTomKnN7H4jaif0hWAECFU2WvRbhfkYWHdlk/JtJM53iIJVL3mKWBRZ0QXITjmgfdIo3c9RcX+wFI7gGqGd6g==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.10.tgz",
+      "integrity": "sha512-xYF+Vgc+j6iPboR0uptQk3QFed5n/0KSgITbfV/uPEqhzSNdkiM4Y2i/sKlTZrI07cRK/m/dbZ6sZsbvXJVtkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13057,9 +13057,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.0.tgz",
-      "integrity": "sha512-4eirfZ7thblFmqFjywlTmuWVSvccHAJbn1r8qQLzmTO11qcqpohOjmY2mFce6x7x7WtskzRqApPD0hv+Oa74jg==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.1.tgz",
+      "integrity": "sha512-thuTRd7F4m4dReCIy7vv4eNYnU6XI/tHMLSMMHLiortw/Y0QxqKtinG523U2aerzwYWGi606oBP4oMPy4+edag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17785,9 +17785,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
-      "integrity": "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.4.tgz",
+      "integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -17861,9 +17861,9 @@
       }
     },
     "node_modules/vite/node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz",
-      "integrity": "sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.1.tgz",
+      "integrity": "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw==",
       "cpu": [
         "arm"
       ],
@@ -17876,9 +17876,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.0.tgz",
-      "integrity": "sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.1.tgz",
+      "integrity": "sha512-PPkxTOisoNC6TpnDKatjKkjRMsdaWIhyuMkA4UsBXT9WEZY4uHezBTjs6Vl4PbqQQeu6oION1w2voYZv9yquCw==",
       "cpu": [
         "arm64"
       ],
@@ -17891,9 +17891,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.0.tgz",
-      "integrity": "sha512-GwYOcOakYHdfnjjKwqpTGgn5a6cUX7+Ra2HeNj/GdXvO2VJOOXCiYYlRFU4CubFM67EhbmzLOmACKEfvp3J1kQ==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.1.tgz",
+      "integrity": "sha512-VWXGISWFY18v/0JyNUy4A46KCFCb9NVsH+1100XP31lud+TzlezBbz24CYzbnA4x6w4hx+NYCXDfnvDVO6lcAA==",
       "cpu": [
         "arm64"
       ],
@@ -17906,9 +17906,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.0.tgz",
-      "integrity": "sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.1.tgz",
+      "integrity": "sha512-nIwkXafAI1/QCS7pxSpv/ZtFW6TXcNUEHAIA9EIyw5OzxJZQ1YDrX+CL6JAIQgZ33CInl1R6mHet9Y/UZTg2Bw==",
       "cpu": [
         "x64"
       ],
@@ -17921,9 +17921,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.0.tgz",
-      "integrity": "sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.1.tgz",
+      "integrity": "sha512-BdrLJ2mHTrIYdaS2I99mriyJfGGenSaP+UwGi1kB9BLOCu9SR8ZpbkmmalKIALnRw24kM7qCN0IOm6L0S44iWw==",
       "cpu": [
         "arm64"
       ],
@@ -17936,9 +17936,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.0.tgz",
-      "integrity": "sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.1.tgz",
+      "integrity": "sha512-VXeo/puqvCG8JBPNZXZf5Dqq7BzElNJzHRRw3vjBE27WujdzuOPecDPc/+1DcdcTptNBep3861jNq0mYkT8Z6Q==",
       "cpu": [
         "x64"
       ],
@@ -17951,9 +17951,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.0.tgz",
-      "integrity": "sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.1.tgz",
+      "integrity": "sha512-ehSKrewwsESPt1TgSE/na9nIhWCosfGSFqv7vwEtjyAqZcvbGIg4JAcV7ZEh2tfj/IlfBeZjgOXm35iOOjadcg==",
       "cpu": [
         "arm"
       ],
@@ -17966,9 +17966,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.0.tgz",
-      "integrity": "sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.1.tgz",
+      "integrity": "sha512-m39iO/aaurh5FVIu/F4/Zsl8xppd76S4qoID8E+dSRQvTyZTOI2gVk3T4oqzfq1PtcvOfAVlwLMK3KRQMaR8lg==",
       "cpu": [
         "arm"
       ],
@@ -17981,9 +17981,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.0.tgz",
-      "integrity": "sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.1.tgz",
+      "integrity": "sha512-Y+GHnGaku4aVLSgrT0uWe2o2Rq8te9hi+MwqGF9r9ORgXhmHK5Q71N757u0F8yU1OIwUIFy6YiJtKjtyktk5hg==",
       "cpu": [
         "arm64"
       ],
@@ -17996,9 +17996,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.0.tgz",
-      "integrity": "sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.1.tgz",
+      "integrity": "sha512-jEwjn3jCA+tQGswK3aEWcD09/7M5wGwc6+flhva7dsQNRZZTe30vkalgIzV4tjkopsTS9Jd7Y1Bsj6a4lzz8gQ==",
       "cpu": [
         "arm64"
       ],
@@ -18011,9 +18011,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.0.tgz",
-      "integrity": "sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.1.tgz",
+      "integrity": "sha512-ySyWikVhNzv+BV/IDCsrraOAZ3UaC8SZB67FZlqVwXwnFhPihOso9rPOxzZbjp81suB1O2Topw+6Ug3JNegejQ==",
       "cpu": [
         "loong64"
       ],
@@ -18026,9 +18026,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.0.tgz",
-      "integrity": "sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.1.tgz",
+      "integrity": "sha512-BvvA64QxZlh7WZWqDPPdt0GH4bznuL6uOO1pmgPnnv86rpUpc8ZxgZwcEgXvo02GRIZX1hQ0j0pAnhwkhwPqWg==",
       "cpu": [
         "ppc64"
       ],
@@ -18041,9 +18041,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.0.tgz",
-      "integrity": "sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.1.tgz",
+      "integrity": "sha512-EQSP+8+1VuSulm9RKSMKitTav89fKbHymTf25n5+Yr6gAPZxYWpj3DzAsQqoaHAk9YX2lwEyAf9S4W8F4l3VBQ==",
       "cpu": [
         "riscv64"
       ],
@@ -18056,9 +18056,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.0.tgz",
-      "integrity": "sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.1.tgz",
+      "integrity": "sha512-h8d28xzYb98fMQKUz0w2fMc1XuGzLLjdyxVIbhbil4ELfk5/orZlSTpF/xdI9C8K0I8lCkq+1En2RJsawZekkg==",
       "cpu": [
         "s390x"
       ],
@@ -18071,9 +18071,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
-      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.1.tgz",
+      "integrity": "sha512-XiK5z70PEFEFqcNj3/zRSz/qX4bp4QIraTy9QjwJAb/Z8GM7kVUsD0Uk8maIPeTyPCP03ChdI+VVmJriKYbRHQ==",
       "cpu": [
         "x64"
       ],
@@ -18086,9 +18086,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.0.tgz",
-      "integrity": "sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.1.tgz",
+      "integrity": "sha512-2BRORitq5rQ4Da9blVovzNCMaUlyKrzMSvkVR0D4qPuOy/+pMCrh1d7o01RATwVy+6Fa1WBw+da7QPeLWU/1mQ==",
       "cpu": [
         "x64"
       ],
@@ -18101,9 +18101,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.0.tgz",
-      "integrity": "sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.1.tgz",
+      "integrity": "sha512-b2bcNm9Kbde03H+q+Jjw9tSfhYkzrDUf2d5MAd1bOJuVplXvFhWz7tRtWvD8/ORZi7qSCy0idW6tf2HgxSXQSg==",
       "cpu": [
         "arm64"
       ],
@@ -18116,9 +18116,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.0.tgz",
-      "integrity": "sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.1.tgz",
+      "integrity": "sha512-DfcogW8N7Zg7llVEfpqWMZcaErKfsj9VvmfSyRjCyo4BI3wPEfrzTtJkZG6gKP/Z92wFm6rz2aDO7/JfiR/whA==",
       "cpu": [
         "ia32"
       ],
@@ -18131,9 +18131,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.0.tgz",
-      "integrity": "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.1.tgz",
+      "integrity": "sha512-ECyOuDeH3C1I8jH2MK1RtBJW+YPMvSfT0a5NN0nHfQYnDSJ6tUiZH3gzwVP5/Kfh/+Tt7tpWVF9LXNTnhTJ3kA==",
       "cpu": [
         "x64"
       ],
@@ -18154,9 +18154,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/rollup": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.0.tgz",
-      "integrity": "sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.1.tgz",
+      "integrity": "sha512-C5VvvgCCyfyotVITIAv+4efVytl5F7wt+/I2i9q9GZcEXW9BP52YYOXC58igUi+LFZVHukErIIqQSWwv/M3WRw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -18171,26 +18171,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.40.0",
-        "@rollup/rollup-android-arm64": "4.40.0",
-        "@rollup/rollup-darwin-arm64": "4.40.0",
-        "@rollup/rollup-darwin-x64": "4.40.0",
-        "@rollup/rollup-freebsd-arm64": "4.40.0",
-        "@rollup/rollup-freebsd-x64": "4.40.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.40.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.40.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.40.0",
-        "@rollup/rollup-linux-arm64-musl": "4.40.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.40.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.40.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.40.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.40.0",
-        "@rollup/rollup-linux-x64-gnu": "4.40.0",
-        "@rollup/rollup-linux-x64-musl": "4.40.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.40.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.40.0",
-        "@rollup/rollup-win32-x64-msvc": "4.40.0",
+        "@rollup/rollup-android-arm-eabi": "4.40.1",
+        "@rollup/rollup-android-arm64": "4.40.1",
+        "@rollup/rollup-darwin-arm64": "4.40.1",
+        "@rollup/rollup-darwin-x64": "4.40.1",
+        "@rollup/rollup-freebsd-arm64": "4.40.1",
+        "@rollup/rollup-freebsd-x64": "4.40.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.40.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.40.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.40.1",
+        "@rollup/rollup-linux-arm64-musl": "4.40.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.40.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.40.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.40.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.40.1",
+        "@rollup/rollup-linux-x64-gnu": "4.40.1",
+        "@rollup/rollup-linux-x64-musl": "4.40.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.40.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.40.1",
+        "@rollup/rollup-win32-x64-msvc": "4.40.1",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^19.2.8"
+    "@angular/core": "^19.2.9"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^19.2.9",
-    "@angular/cli": "^19.2.9",
-    "@angular/common": "^19.2.8",
-    "@angular/compiler": "^19.2.8",
-    "@angular/compiler-cli": "^19.2.8",
-    "@angular/platform-browser": "^19.2.8",
-    "@angular/platform-browser-dynamic": "^19.2.8",
+    "@angular-devkit/build-angular": "^19.2.10",
+    "@angular/cli": "^19.2.10",
+    "@angular/common": "^19.2.9",
+    "@angular/compiler": "^19.2.9",
+    "@angular/compiler-cli": "^19.2.9",
+    "@angular/platform-browser": "^19.2.9",
+    "@angular/platform-browser-dynamic": "^19.2.9",
     "@types/jasmine": "^5.1.7",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.15.3",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 32 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       19.2.9 -> 19.2.10        ng update @angular/cli
      @angular/core                      19.2.8 -> 19.2.9         ng update @angular/core
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>