### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "devDependencies": {
-        "@angular-devkit/build-angular": "^19.2.12",
-        "@angular/cli": "^19.2.12",
-        "@angular/common": "^19.2.11",
-        "@angular/compiler": "^19.2.11",
-        "@angular/compiler-cli": "^19.2.11",
-        "@angular/platform-browser": "^19.2.11",
-        "@angular/platform-browser-dynamic": "^19.2.11",
+        "@angular-devkit/build-angular": "^19.2.13",
+        "@angular/cli": "^19.2.13",
+        "@angular/common": "^19.2.13",
+        "@angular/compiler": "^19.2.13",
+        "@angular/compiler-cli": "^19.2.13",
+        "@angular/platform-browser": "^19.2.13",
+        "@angular/platform-browser-dynamic": "^19.2.13",
         "@types/jasmine": "^5.1.8",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^22.15.21",
-        "angular-eslint": "19.4.0",
+        "angular-eslint": "19.5.0",
         "core-js": "^3.42.0",
         "eslint": "^9.27.0",
         "husky": "^9.1.7",
@@ -42,7 +42,7 @@
         "zone.js": "^0.15.1"
       },
       "peerDependencies": {
-        "@angular/core": "^19.2.11"
+        "@angular/core": "^19.2.13"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -58,13 +58,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1902.12",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.12.tgz",
-      "integrity": "sha512-LfUc7k84YL290hAxsG+FvjQpXugQXyw5aDzrQQB4iTYhBgaABu2aaNOU4eu3JH+F8NeXd2EBF/YMr2LDSkYlMw==",
+      "version": "0.1902.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.13.tgz",
+      "integrity": "sha512-ZMj+PjK22Ph2U8usG6L7LqEfvWlbaOvmiWXSrEt9YiC9QJt6rsumCkOgUIsmHQtucm/lK+9CMtyYdwH2fYycjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.12",
+        "@angular-devkit/core": "19.2.13",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.12.tgz",
-      "integrity": "sha512-v5pdfZHZ8MTZozfpkhKoPFBpXQW+2GFbTfdyis8FBtevJWCbIsCR3xhodgI4jwzkSEAraN4oVtWvSytdNyBC6A==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.13.tgz",
+      "integrity": "sha512-iq73hE5Uvms1w3uMUSk4i4NDXDMQ863VAifX8LOTadhG6U0xISjNJ11763egVCxQmaKmg7zbG4rda88wHJATzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -146,17 +146,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.12.tgz",
-      "integrity": "sha512-gPx3Vi7QFzHkSV388en6VqSqasojitJKuKmgTMPOV5keLtpOylPv3rjnr8oO9rYbYmLsT/WTUsP7bYiZhrr19Q==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.13.tgz",
+      "integrity": "sha512-MrNpwrCq6COszhxyD/u2LE0yygTEjIAlaKaIvvDi9nurzUoKRc1vIJWeB2VkGgmUEjj6OTEeM/6zbo02s88EzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1902.12",
-        "@angular-devkit/build-webpack": "0.1902.12",
-        "@angular-devkit/core": "19.2.12",
-        "@angular/build": "19.2.12",
+        "@angular-devkit/architect": "0.1902.13",
+        "@angular-devkit/build-webpack": "0.1902.13",
+        "@angular-devkit/core": "19.2.13",
+        "@angular/build": "19.2.13",
         "@babel/core": "7.26.10",
         "@babel/generator": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
@@ -167,7 +167,7 @@
         "@babel/preset-env": "7.26.9",
         "@babel/runtime": "7.26.10",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "19.2.12",
+        "@ngtools/webpack": "19.2.13",
         "@vitejs/plugin-basic-ssl": "1.2.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -221,7 +221,7 @@
         "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
         "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
         "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
-        "@angular/ssr": "^19.2.12",
+        "@angular/ssr": "^19.2.13",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.12.tgz",
-      "integrity": "sha512-v5pdfZHZ8MTZozfpkhKoPFBpXQW+2GFbTfdyis8FBtevJWCbIsCR3xhodgI4jwzkSEAraN4oVtWvSytdNyBC6A==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.13.tgz",
+      "integrity": "sha512-iq73hE5Uvms1w3uMUSk4i4NDXDMQ863VAifX8LOTadhG6U0xISjNJ11763egVCxQmaKmg7zbG4rda88wHJATzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -421,13 +421,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1902.12",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1902.12.tgz",
-      "integrity": "sha512-JNwvzaN2RVbG1IClFPXhNpysVwf55nWmVsNN5iQHRXkD3kpqnaOfhUBtlhBBjLf/i6cwKEne2TI8zciaEYr+iw==",
+      "version": "0.1902.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1902.13.tgz",
+      "integrity": "sha512-upb+cKWkuXwmKyppSwZf3ryHWPm4aS6sJkQu0TWh4RoMRp1WCYVxUfgZ28fTMqcBF3eoFy2XPjdOfkJDRb6Hrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1902.12",
+        "@angular-devkit/architect": "0.1902.13",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -451,13 +451,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.12.tgz",
-      "integrity": "sha512-vK5NI/asi1snWFkw02DpmC8tLq6u5ZbUwwXxgALKuVwGl3g1VLzrHrkoSCrcsOO9Nu6GQOPbxax2lR/DICmytg==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.13.tgz",
+      "integrity": "sha512-NhSPz3lI9njEo8eMUlZVGtlXl12UcNZv5lWTBZY/FGWUu6P5ciD/9iJINbc1jiaDH5E/DLEicUNuai0Q91X4Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.12",
+        "@angular-devkit/core": "19.2.13",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.12.tgz",
-      "integrity": "sha512-v5pdfZHZ8MTZozfpkhKoPFBpXQW+2GFbTfdyis8FBtevJWCbIsCR3xhodgI4jwzkSEAraN4oVtWvSytdNyBC6A==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.13.tgz",
+      "integrity": "sha512-iq73hE5Uvms1w3uMUSk4i4NDXDMQ863VAifX8LOTadhG6U0xISjNJ11763egVCxQmaKmg7zbG4rda88wHJATzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -542,9 +542,9 @@
       }
     },
     "node_modules/@angular-eslint/builder": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-19.4.0.tgz",
-      "integrity": "sha512-+mI/YwXiT+IPRNuTNrQqOm97iqbPM5Zc4fxR3p9N1xj1dxLyXJrtGXbbWJPK6i74ON7KdpkY3WLhMKnhWM4RzQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-19.5.0.tgz",
+      "integrity": "sha512-alYhEnZcA4RMfgC8AMMl29q77KhvfH9D0x80UPgd0XBUua94iYJky/Ng/LKq7gcIDWPRvEYCd5Tbmk4xfsmJVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -557,9 +557,9 @@
       }
     },
     "node_modules/@angular-eslint/builder/node_modules/@angular-devkit/core": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.11.tgz",
-      "integrity": "sha512-hXacCEbLbVo/PYPHBhaU2LThFm0Q1tIGTsWSkQjtsQpW8e4xqgSnFIWaHdsPiiGryxtdtvNE2cr9qa0ddAJOnA==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.13.tgz",
+      "integrity": "sha512-iq73hE5Uvms1w3uMUSk4i4NDXDMQ863VAifX8LOTadhG6U0xISjNJ11763egVCxQmaKmg7zbG4rda88wHJATzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -629,21 +629,21 @@
       }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-19.4.0.tgz",
-      "integrity": "sha512-Djq+je34czagDxvkBbbe1dLlhUGYK2MbHjEgPTQ00tVkacLQGAW4UmT1A0JGZzfzl/lDVvli64/lYQsJTSSM6A==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-19.5.0.tgz",
+      "integrity": "sha512-k75d3oQaF4F4a3Rk3JLBGtcmCNlaI5TlMSleKTMhKRrsD0nqDc+b5iFc/+JUzB9I5E6SovgMueU13ZdZfXZGZg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.4.0.tgz",
-      "integrity": "sha512-jXhyYYIdo5ItCFfmw7W5EqDRQx8rYtiYbpezI84CemKPHB/VPiP/zqLIvdTVBdJdXlqS31ueXn2YlWU0w6AAgg==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.5.0.tgz",
+      "integrity": "sha512-9hxPnX5rWCCH2Qga30Plym2eDXXetS0luPuOl0kHqdXQ/MB6j6tuSWcLKmqKlCRFe7/G9qEJoiblUvex6gwb9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.4.0",
-        "@angular-eslint/utils": "19.4.0"
+        "@angular-eslint/bundled-angular-compiler": "19.5.0",
+        "@angular-eslint/utils": "19.5.0"
       },
       "peerDependencies": {
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
@@ -652,14 +652,14 @@
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.4.0.tgz",
-      "integrity": "sha512-6WAGnHf5SKi7k8/AOOLwGCoN3iQUE8caKsg0OucL4CWPUyzsYpQjx7ALKyxx9lqoAngn3CTlQ2tcwDv6aYtfmg==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.5.0.tgz",
+      "integrity": "sha512-xDlxptxYelH6MuP48PE10cKDU+EHNYxDvsRmcUmP84MHP69VMAlmAAIS1j9y0UtfHrB1JxlKdsTU7cWH2YeWqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.4.0",
-        "@angular-eslint/utils": "19.4.0",
+        "@angular-eslint/bundled-angular-compiler": "19.5.0",
+        "@angular-eslint/utils": "19.5.0",
         "aria-query": "5.3.2",
         "axobject-query": "4.1.0"
       },
@@ -671,25 +671,25 @@
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-19.4.0.tgz",
-      "integrity": "sha512-gW6RkLC5/CHiD1CXjve6LO0iit0EbHyhV6Jnb7FeRhTaFHhktbuI0zQ8wnSI/D0Pm8ZvV1PoNyhB2k2AWZT9sQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-19.5.0.tgz",
+      "integrity": "sha512-1IgJPJDwlYdMWaY4L5amO83G8aHy5PXFkoL2ijlHIBxJFA2ltn4aMai1LdsntQTViJ3zsbK6L3xLHM26cDzeRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": ">= 19.0.0 < 20.0.0",
         "@angular-devkit/schematics": ">= 19.0.0 < 20.0.0",
-        "@angular-eslint/eslint-plugin": "19.4.0",
-        "@angular-eslint/eslint-plugin-template": "19.4.0",
+        "@angular-eslint/eslint-plugin": "19.5.0",
+        "@angular-eslint/eslint-plugin-template": "19.5.0",
         "ignore": "7.0.4",
-        "semver": "7.7.1",
+        "semver": "7.7.2",
         "strip-json-comments": "3.1.1"
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.11.tgz",
-      "integrity": "sha512-hXacCEbLbVo/PYPHBhaU2LThFm0Q1tIGTsWSkQjtsQpW8e4xqgSnFIWaHdsPiiGryxtdtvNE2cr9qa0ddAJOnA==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.13.tgz",
+      "integrity": "sha512-iq73hE5Uvms1w3uMUSk4i4NDXDMQ863VAifX8LOTadhG6U0xISjNJ11763egVCxQmaKmg7zbG4rda88wHJATzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -768,14 +768,27 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@angular-eslint/schematics/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@angular-eslint/template-parser": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-19.4.0.tgz",
-      "integrity": "sha512-f4t7Z6zo8owOTUqAtZ3G/cMA5hfT3RE2OKR0dLn7YI6LxUJkrlcHq75n60UHiapl5sais6heo70hvjQgJ3fDxQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-19.5.0.tgz",
+      "integrity": "sha512-Cgv0FXnJW0y+metp5a6QhGhWPKcuWAPZjza5KqjrRM3AtANqX4lH3mLplQ2DlN7On1zQEVQ3l8IQ2C6lxBHshA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.4.0",
+        "@angular-eslint/bundled-angular-compiler": "19.5.0",
         "eslint-scope": "^8.0.2"
       },
       "peerDependencies": {
@@ -784,13 +797,13 @@
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-19.4.0.tgz",
-      "integrity": "sha512-2hZ7rf/0YBkn1Rk0i7AlYGlfxQ7+DqEXUsgp1M56mf0cy7/GCFiWZE0lcXFY4kzb4yQK3G2g+kIF092MwelT7Q==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-19.5.0.tgz",
+      "integrity": "sha512-s9ec5WAGppuqkYCU6yXg2jsz95Cbqo8eY5xNftI+4AiMP9YEwNwe212U1Z7OxHDvS1TbQGb6Vp0dJcgAmqs5bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.4.0"
+        "@angular-eslint/bundled-angular-compiler": "19.5.0"
       },
       "peerDependencies": {
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
@@ -799,14 +812,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.2.12.tgz",
-      "integrity": "sha512-G28ux1T5QDlWporwupWbcodBN3rcyHfK2Dh5M3UC5hj0GstpfEHcpBHxawZzIxhqPKy//tdVLlzORUgvAwnqbA==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.2.13.tgz",
+      "integrity": "sha512-ABcwhAB9DpsvXY7joRFSKiQCHJmCokVJK1Liuz0/AI9Xlp7spqaWqJcC1DVWO0645tUk4HhYmUh5a68REK1Q1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1902.12",
+        "@angular-devkit/architect": "0.1902.13",
         "@babel/core": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -846,7 +859,7 @@
         "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
         "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
         "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
-        "@angular/ssr": "^19.2.12",
+        "@angular/ssr": "^19.2.13",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^19.0.0 || ^19.2.0-next.0",
@@ -1005,18 +1018,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.12.tgz",
-      "integrity": "sha512-cZkHpM16uh3VouHG1XdWSk0ZWisQRxMVADk5IJlM9jMcPqnFyJwD/UXCS+XTaW3POpNDwsmbh2UB9Xabdgo7rw==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.13.tgz",
+      "integrity": "sha512-dDRCS73/lrItWx9j4SmwHR56GiZsW8ObNi2q9l/1ny813CG9K43STYFG/wJvGS7ZF3y5hvjIiJOwBx2YIouOIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1902.12",
-        "@angular-devkit/core": "19.2.12",
-        "@angular-devkit/schematics": "19.2.12",
+        "@angular-devkit/architect": "0.1902.13",
+        "@angular-devkit/core": "19.2.13",
+        "@angular-devkit/schematics": "19.2.13",
         "@inquirer/prompts": "7.3.2",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.2.12",
+        "@schematics/angular": "19.2.13",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -1039,9 +1052,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.12.tgz",
-      "integrity": "sha512-v5pdfZHZ8MTZozfpkhKoPFBpXQW+2GFbTfdyis8FBtevJWCbIsCR3xhodgI4jwzkSEAraN4oVtWvSytdNyBC6A==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.13.tgz",
+      "integrity": "sha512-iq73hE5Uvms1w3uMUSk4i4NDXDMQ863VAifX8LOTadhG6U0xISjNJ11763egVCxQmaKmg7zbG4rda88wHJATzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1111,9 +1124,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.11.tgz",
-      "integrity": "sha512-/ZnF2Nfp6S6TAu3VlvUAIp4NVd81WE1Q95wuwSSuoEx2aSyXzI+1myyKWSYe/jYCyGuppmocjTciEh8mAInmOw==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.13.tgz",
+      "integrity": "sha512-k7I4bLH+bgI02VL81MaL0NcZPfVl153KAiARwk+ZlkmQjMnWlmsAHQ6054SWoNEXwP855ATR6YYDVqJh8TZaqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1123,14 +1136,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.2.11",
+        "@angular/core": "19.2.13",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.11.tgz",
-      "integrity": "sha512-/ZGFAEO2TyqkaE4neR8lGL9I2QeO2sRVFqulQv7Bu8zKTPStjcsFCwNkp+TNX8Oq/1rLcY9XWAOsUk1//AZd8Q==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.13.tgz",
+      "integrity": "sha512-xAj1peVrQtb65NsULmz8ocH4QZ4ESG5YiiVzJ0tLz8t280xY+QhJiM6C0+jaCVHLXvZp0c7GEzsYjL6x1HmabQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1141,9 +1154,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.11.tgz",
-      "integrity": "sha512-15aoOg+qj7Z3Uap1JKHMy51y12M09AOnseDBa0SYKidSx15XwZi8d01hv7sRaQJX/6Ie5cug9GiAbLKts6R33w==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.13.tgz",
+      "integrity": "sha512-SSuzKMcktvd6VexivDwhP7ctQBD6yyoo5E91I7Frn5nrvYNM+TIyYcXmJ4dgby5/GrPZGfm2sWl3ARr2vbCgtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1165,7 +1178,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.2.11",
+        "@angular/compiler": "19.2.13",
         "typescript": ">=5.5 <5.9"
       }
     },
@@ -1196,9 +1209,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.11.tgz",
-      "integrity": "sha512-kmtJQB7B5F2V1JIzy1oBPS6WrRyedSYkuge+XoX1mCSFJDef8HRNd7GopnQ0Zaz0vOTGvCCkWvvaH/+7s2lmAQ==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.13.tgz",
+      "integrity": "sha512-HpzDI3TSQzVV2mmQ8KwH0JSLNlYNemNrEo3L3hcqqYwTzqFgAK4y1Q2Xym3yiRSLTenYhW5D4CQqOHUQ26HxwQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1213,9 +1226,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.11.tgz",
-      "integrity": "sha512-wAPJtgzmxBEpW31sa2eg9QssCHBZ52Zc9nm6azTflDlOAyfm9bzqec7y3wqy5sgVue/qID2gzHqmpS3Nx3o0xg==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.13.tgz",
+      "integrity": "sha512-YeuRfGbo8qFepoAUoubk/1079wOown5Qgr9eAhgCXxoXb2rt87xbJF3YCSSim38SP3kK1rJQqP+Sr8n7ef+n5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1225,9 +1238,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.2.11",
-        "@angular/common": "19.2.11",
-        "@angular/core": "19.2.11"
+        "@angular/animations": "19.2.13",
+        "@angular/common": "19.2.13",
+        "@angular/core": "19.2.13"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1236,9 +1249,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.11.tgz",
-      "integrity": "sha512-1/0FmjSAvsK+A6gWLgEc60YMnWQchP9fP6y4sE1uQOThIgK+qLnLjZqZn7uOw8zMDBMtxB7SlepajnXftVXddw==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.13.tgz",
+      "integrity": "sha512-qbIPwnqkqQZ1sK56cbb2k/qtg+BKYicU6aS/YKfRrEfM9zFNyxfSCdKOwL7hogKGZKJulFfFKpi44wJcdW13rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1248,10 +1261,10 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.2.11",
-        "@angular/compiler": "19.2.11",
-        "@angular/core": "19.2.11",
-        "@angular/platform-browser": "19.2.11"
+        "@angular/common": "19.2.13",
+        "@angular/compiler": "19.2.13",
+        "@angular/core": "19.2.13",
+        "@angular/platform-browser": "19.2.13"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4346,9 +4359,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.12.tgz",
-      "integrity": "sha512-MTxkM+jZPQP55q0BWx/1w2kaN9mSFC14V9+p4sfNm/OXk7fibtxz5lXH/2sDGFWJi36s4gppKqfHBhp9OTdHCQ==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.13.tgz",
+      "integrity": "sha512-9dYfLsqWFTn1YVUiWydSp2bboaSW+byeZRFx8qeR7lsOkDGbm/idG68IXFHybHtZ3ptJ5fEeuw89RL47SQ61oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4966,9 +4979,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.0.tgz",
-      "integrity": "sha512-ieQljaZKuJpmWvd8gW87ZmSFwid6AxMDk5bhONJ57U8zT77zpZ/TPKkU9HpnnFrM4zsgr4kiGuzbIbZTGi7u9A==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.1.tgz",
+      "integrity": "sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==",
       "cpu": [
         "riscv64"
       ],
@@ -5083,14 +5096,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.12.tgz",
-      "integrity": "sha512-6S6tclFctLrjMvhpi8eVvswIpXqlybRpZLCTWyVeWIC6PHYLEyFmFoOhuhcSmOdtnwudvzOt6xWnWEVb3qXZbQ==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.13.tgz",
+      "integrity": "sha512-SOpK4AwH0isXo7Y2SkgXLyGLMw4GxWPAun6sCLiprmop4KlqKGGALn4xIW0yjq0s5GS0Vx0FFjz8bBfPkgnawA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.12",
-        "@angular-devkit/schematics": "19.2.12",
+        "@angular-devkit/core": "19.2.13",
+        "@angular-devkit/schematics": "19.2.13",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -5100,9 +5113,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "19.2.12",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.12.tgz",
-      "integrity": "sha512-v5pdfZHZ8MTZozfpkhKoPFBpXQW+2GFbTfdyis8FBtevJWCbIsCR3xhodgI4jwzkSEAraN4oVtWvSytdNyBC6A==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.13.tgz",
+      "integrity": "sha512-iq73hE5Uvms1w3uMUSk4i4NDXDMQ863VAifX8LOTadhG6U0xISjNJ11763egVCxQmaKmg7zbG4rda88wHJATzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6199,19 +6212,19 @@
       }
     },
     "node_modules/angular-eslint": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-19.4.0.tgz",
-      "integrity": "sha512-/Xg77jhVHqn67AxZL6ELPV6JpwNLZKUTRYYfZcG7ro7CpOgdOXaJg7a1UeZLxFuNGGrfhacBQNX0ajM4Giue7A==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-19.5.0.tgz",
+      "integrity": "sha512-XLYRjKmUrCWIZ6PQ+zZBia5nyKU3WD9MldFJAstCk3LwK/c6apllkB9HWrsMvPADMcAlm8zN64ll3irA/oA95Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": ">= 19.0.0 < 20.0.0",
         "@angular-devkit/schematics": ">= 19.0.0 < 20.0.0",
-        "@angular-eslint/builder": "19.4.0",
-        "@angular-eslint/eslint-plugin": "19.4.0",
-        "@angular-eslint/eslint-plugin-template": "19.4.0",
-        "@angular-eslint/schematics": "19.4.0",
-        "@angular-eslint/template-parser": "19.4.0",
+        "@angular-eslint/builder": "19.5.0",
+        "@angular-eslint/eslint-plugin": "19.5.0",
+        "@angular-eslint/eslint-plugin-template": "19.5.0",
+        "@angular-eslint/schematics": "19.5.0",
+        "@angular-eslint/template-parser": "19.5.0",
         "@typescript-eslint/types": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0"
       },
@@ -16432,9 +16445,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -16482,9 +16495,9 @@
       }
     },
     "node_modules/tree-dump": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
-      "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.3.tgz",
+      "integrity": "sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -17043,9 +17056,9 @@
       }
     },
     "node_modules/vite/node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.0.tgz",
-      "integrity": "sha512-KxN+zCjOYHGwCl4UCtSfZ6jrq/qi88JDUtiEFk8LELEHq2Egfc/FgW+jItZiOLRuQfb/3xJSgFuNPC9jzggX+A==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
+      "integrity": "sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==",
       "cpu": [
         "arm"
       ],
@@ -17058,9 +17071,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.0.tgz",
-      "integrity": "sha512-yDvqx3lWlcugozax3DItKJI5j05B0d4Kvnjx+5mwiUpWramVvmAByYigMplaoAQ3pvdprGCTCE03eduqE/8mPQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.1.tgz",
+      "integrity": "sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA==",
       "cpu": [
         "arm64"
       ],
@@ -17073,9 +17086,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.0.tgz",
-      "integrity": "sha512-2KOU574vD3gzcPSjxO0eyR5iWlnxxtmW1F5CkNOHmMlueKNCQkxR6+ekgWyVnz6zaZihpUNkGxjsYrkTJKhkaw==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.1.tgz",
+      "integrity": "sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==",
       "cpu": [
         "arm64"
       ],
@@ -17088,9 +17101,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.0.tgz",
-      "integrity": "sha512-gE5ACNSxHcEZyP2BA9TuTakfZvULEW4YAOtxl/A/YDbIir/wPKukde0BNPlnBiP88ecaN4BJI2TtAd+HKuZPQQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.1.tgz",
+      "integrity": "sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg==",
       "cpu": [
         "x64"
       ],
@@ -17103,9 +17116,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.0.tgz",
-      "integrity": "sha512-GSxU6r5HnWij7FoSo7cZg3l5GPg4HFLkzsFFh0N/b16q5buW1NAWuCJ+HMtIdUEi6XF0qH+hN0TEd78laRp7Dg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.1.tgz",
+      "integrity": "sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==",
       "cpu": [
         "arm64"
       ],
@@ -17118,9 +17131,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.0.tgz",
-      "integrity": "sha512-KGiGKGDg8qLRyOWmk6IeiHJzsN/OYxO6nSbT0Vj4MwjS2XQy/5emsmtoqLAabqrohbgLWJ5GV3s/ljdrIr8Qjg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.1.tgz",
+      "integrity": "sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA==",
       "cpu": [
         "x64"
       ],
@@ -17133,9 +17146,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.0.tgz",
-      "integrity": "sha512-46OzWeqEVQyX3N2/QdiU/CMXYDH/lSHpgfBkuhl3igpZiaB3ZIfSjKuOnybFVBQzjsLwkus2mjaESy8H41SzvA==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.1.tgz",
+      "integrity": "sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==",
       "cpu": [
         "arm"
       ],
@@ -17148,9 +17161,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.0.tgz",
-      "integrity": "sha512-lfgW3KtQP4YauqdPpcUZHPcqQXmTmH4nYU0cplNeW583CMkAGjtImw4PKli09NFi2iQgChk4e9erkwlfYem6Lg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.1.tgz",
+      "integrity": "sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==",
       "cpu": [
         "arm"
       ],
@@ -17163,9 +17176,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.0.tgz",
-      "integrity": "sha512-nn8mEyzMbdEJzT7cwxgObuwviMx6kPRxzYiOl6o/o+ChQq23gfdlZcUNnt89lPhhz3BYsZ72rp0rxNqBSfqlqw==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.1.tgz",
+      "integrity": "sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==",
       "cpu": [
         "arm64"
       ],
@@ -17178,9 +17191,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.0.tgz",
-      "integrity": "sha512-l+QK99je2zUKGd31Gh+45c4pGDAqZSuWQiuRFCdHYC2CSiO47qUWsCcenrI6p22hvHZrDje9QjwSMAFL3iwXwQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.1.tgz",
+      "integrity": "sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==",
       "cpu": [
         "arm64"
       ],
@@ -17193,9 +17206,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.0.tgz",
-      "integrity": "sha512-WbnJaxPv1gPIm6S8O/Wg+wfE/OzGSXlBMbOe4ie+zMyykMOeqmgD1BhPxZQuDqwUN+0T/xOFtL2RUWBspnZj3w==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.1.tgz",
+      "integrity": "sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==",
       "cpu": [
         "loong64"
       ],
@@ -17208,9 +17221,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.0.tgz",
-      "integrity": "sha512-eRDWR5t67/b2g8Q/S8XPi0YdbKcCs4WQ8vklNnUYLaSWF+Cbv2axZsp4jni6/j7eKvMLYCYdcsv8dcU+a6QNFg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.1.tgz",
+      "integrity": "sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==",
       "cpu": [
         "ppc64"
       ],
@@ -17223,9 +17236,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.0.tgz",
-      "integrity": "sha512-TWrZb6GF5jsEKG7T1IHwlLMDRy2f3DPqYldmIhnA2DVqvvhY2Ai184vZGgahRrg8k9UBWoSlHv+suRfTN7Ua4A==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.1.tgz",
+      "integrity": "sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==",
       "cpu": [
         "riscv64"
       ],
@@ -17238,9 +17251,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.0.tgz",
-      "integrity": "sha512-/L3pW48SxrWAlVsKCN0dGLB2bi8Nv8pr5S5ocSM+S0XCn5RCVCXqi8GVtHFsOBBCSeR+u9brV2zno5+mg3S4Aw==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.1.tgz",
+      "integrity": "sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==",
       "cpu": [
         "s390x"
       ],
@@ -17253,9 +17266,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.0.tgz",
-      "integrity": "sha512-XMLeKjyH8NsEDCRptf6LO8lJk23o9wvB+dJwcXMaH6ZQbbkHu2dbGIUindbMtRN6ux1xKi16iXWu6q9mu7gDhQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.1.tgz",
+      "integrity": "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==",
       "cpu": [
         "x64"
       ],
@@ -17268,9 +17281,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.0.tgz",
-      "integrity": "sha512-m/P7LycHZTvSQeXhFmgmdqEiTqSV80zn6xHaQ1JSqwCtD1YGtwEK515Qmy9DcB2HK4dOUVypQxvhVSy06cJPEg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.1.tgz",
+      "integrity": "sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==",
       "cpu": [
         "x64"
       ],
@@ -17283,9 +17296,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.0.tgz",
-      "integrity": "sha512-4yodtcOrFHpbomJGVEqZ8fzD4kfBeCbpsUy5Pqk4RluXOdsWdjLnjhiKy2w3qzcASWd04fp52Xz7JKarVJ5BTg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.1.tgz",
+      "integrity": "sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==",
       "cpu": [
         "arm64"
       ],
@@ -17298,9 +17311,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.0.tgz",
-      "integrity": "sha512-tmazCrAsKzdkXssEc65zIE1oC6xPHwfy9d5Ta25SRCDOZS+I6RypVVShWALNuU9bxIfGA0aqrmzlzoM5wO5SPQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.1.tgz",
+      "integrity": "sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==",
       "cpu": [
         "ia32"
       ],
@@ -17313,9 +17326,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.0.tgz",
-      "integrity": "sha512-h1J+Yzjo/X+0EAvR2kIXJDuTuyT7drc+t2ALY0nIcGPbTatNOf0VWdhEA2Z4AAjv6X1NJV7SYo5oCTYRJhSlVA==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.1.tgz",
+      "integrity": "sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==",
       "cpu": [
         "x64"
       ],
@@ -17336,9 +17349,9 @@
       "peer": true
     },
     "node_modules/vite/node_modules/rollup": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.0.tgz",
-      "integrity": "sha512-HqMFpUbWlf/tvcxBFNKnJyzc7Lk+XO3FGc3pbNBLqEbOz0gPLRgcrlS3UF4MfUrVlstOaP/q0kM6GVvi+LrLRg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
+      "integrity": "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -17353,26 +17366,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.41.0",
-        "@rollup/rollup-android-arm64": "4.41.0",
-        "@rollup/rollup-darwin-arm64": "4.41.0",
-        "@rollup/rollup-darwin-x64": "4.41.0",
-        "@rollup/rollup-freebsd-arm64": "4.41.0",
-        "@rollup/rollup-freebsd-x64": "4.41.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.41.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.41.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.41.0",
-        "@rollup/rollup-linux-arm64-musl": "4.41.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.41.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.41.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.41.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.41.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.41.0",
-        "@rollup/rollup-linux-x64-gnu": "4.41.0",
-        "@rollup/rollup-linux-x64-musl": "4.41.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.41.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.41.0",
-        "@rollup/rollup-win32-x64-msvc": "4.41.0",
+        "@rollup/rollup-android-arm-eabi": "4.41.1",
+        "@rollup/rollup-android-arm64": "4.41.1",
+        "@rollup/rollup-darwin-arm64": "4.41.1",
+        "@rollup/rollup-darwin-x64": "4.41.1",
+        "@rollup/rollup-freebsd-arm64": "4.41.1",
+        "@rollup/rollup-freebsd-x64": "4.41.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.41.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.41.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.41.1",
+        "@rollup/rollup-linux-arm64-musl": "4.41.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.41.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.41.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.41.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.41.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.41.1",
+        "@rollup/rollup-linux-x64-gnu": "4.41.1",
+        "@rollup/rollup-linux-x64-musl": "4.41.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.41.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.41.1",
+        "@rollup/rollup-win32-x64-msvc": "4.41.1",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,20 +27,20 @@
     "url": "https://github.com/fast-facts/ngx-pipes.git"
   },
   "peerDependencies": {
-    "@angular/core": "^19.2.11"
+    "@angular/core": "^19.2.13"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^19.2.12",
-    "@angular/cli": "^19.2.12",
-    "@angular/common": "^19.2.11",
-    "@angular/compiler": "^19.2.11",
-    "@angular/compiler-cli": "^19.2.11",
-    "@angular/platform-browser": "^19.2.11",
-    "@angular/platform-browser-dynamic": "^19.2.11",
+    "@angular-devkit/build-angular": "^19.2.13",
+    "@angular/cli": "^19.2.13",
+    "@angular/common": "^19.2.13",
+    "@angular/compiler": "^19.2.13",
+    "@angular/compiler-cli": "^19.2.13",
+    "@angular/platform-browser": "^19.2.13",
+    "@angular/platform-browser-dynamic": "^19.2.13",
     "@types/jasmine": "^5.1.8",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^22.15.21",
-    "angular-eslint": "19.4.0",
+    "angular-eslint": "19.5.0",
     "core-js": "^3.42.0",
     "eslint": "^9.27.0",
     "husky": "^9.1.7",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: [90mnpm[39m
Collecting installed dependencies...
Found 32 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       19.2.12 -> 19.2.13       ng update @angular/cli
      @angular/core                      19.2.11 -> 19.2.13       ng update @angular/core
      angular-eslint                     19.4.0 -> 19.5.0         ng update angular-eslint
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>